### PR TITLE
Add attachment for variant

### DIFF
--- a/pkg/mapper/entity_restapi/r2e/r2e.go
+++ b/pkg/mapper/entity_restapi/r2e/r2e.go
@@ -1,9 +1,12 @@
 package r2e
 
 import (
+	"fmt"
+
 	"github.com/checkr/flagr/pkg/entity"
 	"github.com/checkr/flagr/pkg/util"
 	"github.com/checkr/flagr/swagger_gen/models"
+	"github.com/davecgh/go-spew/spew"
 )
 
 // MapDistributions maps distribution
@@ -25,4 +28,24 @@ func MapDistribution(r *models.Distribution, segmentID uint) entity.Distribution
 		Bitmap:     r.Bitmap,
 	}
 	return e
+}
+
+// MapAttachment maps attachment
+func MapAttachment(a interface{}) (entity.Attachment, error) {
+	e := entity.Attachment{}
+
+	if a != nil {
+		m, ok := a.(map[string]interface{})
+		if !ok {
+			return e, fmt.Errorf("all key/value pairs should be string/string. invalid attachment format %s", spew.Sdump(a))
+		}
+		for k, v := range m {
+			s, ok := v.(string)
+			if !ok {
+				return e, fmt.Errorf("all key/value pairs should be string/string. invalid attachment format %s", spew.Sdump(a))
+			}
+			e[k] = s
+		}
+	}
+	return e, nil
 }


### PR DESCRIPTION
Add attachment to the variant restapi. Attachment is the dynamic configuration part of the system. For simplicity, only string => string are supported.

```
curl --request POST \
  --url http://localhost:18000/api/flags/1/variants \
  --header 'content-type: application/json' \
  --data '{\n	"key": "treatment",\n	"attachment": {\n		"hi": "321"\n	}\n}'

{
	"attachment": {
		"hi": "321"
	},
	"id": 6,
	"key": "treatment"
}


curl --request POST \
  --url http://localhost:18000/api/flags/1/variants \
  --header 'content-type: application/json' \
  --data '{\n	"key": "treatment",\n	"attachment": {\n		"hi": 321\n	}\n}'

{
	"message": "all key/value pairs should be string/string. invalid attachment format (map[string]interface {}) (len=1) {\n (string) (len=2) \"hi\": (json.Number) (len=3) 321\n}\n"
}
```