### PR TITLE
Fix segment stable sort with asc segmentID

### DIFF
--- a/pkg/entity/flag.go
+++ b/pkg/entity/flag.go
@@ -34,7 +34,7 @@ type FlagEvaluation struct {
 func (f *Flag) Preload(db *gorm.DB) error {
 	ss := []Segment{}
 	segmentQuery := NewSegmentQuerySet(db)
-	if err := segmentQuery.FlagIDEq(f.ID).OrderAscByRank().All(&ss); err != nil {
+	if err := segmentQuery.FlagIDEq(f.ID).OrderAscByRank().OrderAscByID().All(&ss); err != nil {
 		return err
 	}
 	for i, s := range ss {

--- a/pkg/handler/crud.go
+++ b/pkg/handler/crud.go
@@ -197,7 +197,7 @@ func (c *crud) FindSegments(params segment.FindSegmentsParams) middleware.Respon
 	ss := []entity.Segment{}
 
 	q := entity.NewSegmentQuerySet(repo.GetDB())
-	err := q.FlagIDEq(uint(params.FlagID)).OrderAscByRank().All(&ss)
+	err := q.FlagIDEq(uint(params.FlagID)).OrderAscByRank().OrderAscByID().All(&ss)
 	if err != nil {
 		return segment.NewFindSegmentsDefault(500).WithPayload(ErrorMessage("%s", err))
 	}


### PR DESCRIPTION
If the rank of segments are the same, use explicit ID to guarantee the order of the segments