### PR TITLE
Add eager preload to avoid n+1 problem

### DIFF
--- a/pkg/entity/segment.go
+++ b/pkg/entity/segment.go
@@ -7,6 +7,9 @@ import (
 	"github.com/zhouzhuojie/conditions"
 )
 
+// SegmentDefaultRank is the default rank when we create the segment
+const SegmentDefaultRank = uint(999)
+
 // Segment is the unit of segmentation
 // gen:qs
 type Segment struct {

--- a/pkg/handler/crud.go
+++ b/pkg/handler/crud.go
@@ -202,6 +202,7 @@ func (c *crud) CreateSegment(params segment.CreateSegmentParams) middleware.Resp
 	s.FlagID = uint(params.FlagID)
 	s.RolloutPercent = uint(*params.Body.RolloutPercent)
 	s.Description = util.SafeString(params.Body.Description)
+	s.Rank = entity.SegmentDefaultRank
 
 	err := s.Create(getDB())
 	if err != nil {


### PR DESCRIPTION
Use the preload feature from gorm to avoid the n+1 problem

tested with my local, and the gorm debug SQL

```
SELECT * FROM "flags"  WHERE "flags".deleted_at IS NULL[]
SELECT * FROM "segments"  WHERE "segments".deleted_at IS NULL AND (("flag_id" IN (?,?))) ORDER BY Segments.Rank ASC,Segments.Id ASC[1 3]
SELECT * FROM "distributions"  WHERE "distributions".deleted_at IS NULL AND (("segment_id" IN (?,?,?,?,?))) ORDER BY Distributions.variant_id ASC[2 7 8 6 9]
SELECT * FROM "constraints"  WHERE "constraints".deleted_at IS NULL AND (("segment_id" IN (?,?,?,?,?))) ORDER BY Constraints.created_at ASC[2 7 8 6 9]
SELECT * FROM "variants"  WHERE "variants".deleted_at IS NULL AND (("flag_id" IN (?,?)))[1 3]

```