### PR TITLE
Use multi-stage build for dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,19 @@
-FROM checkr/flagr-ci
-
-VOLUME ["/data"]
-
+FROM checkr/flagr-ci as builder
 WORKDIR /go/src/github.com/checkr/flagr
 ADD . .
-ADD ./buildscripts/demo_sqlite3.db /data/demo_sqlite3.db
+RUN cd ./browser/flagr-ui/ && yarn install && yarn run build
+RUN make build
 
+FROM alpine:3.6
+RUN apk add --no-cache libc6-compat
+WORKDIR /go/src/github.com/checkr/flagr
+VOLUME ["/data"]
+ADD ./buildscripts/demo_sqlite3.db /data/demo_sqlite3.db
 ENV FLAGR_DB_DBCONNECTIONSTR=/data/demo_sqlite3.db
 ENV FLAGR_RECORDER_ENABLED=false
 ENV HOST=0.0.0.0
 ENV PORT=18000
-
-RUN cd ./browser/flagr-ui/ && yarn install && yarn run build
-RUN make build
-
+COPY --from=builder /go/src/github.com/checkr/flagr/flagr ./flagr
+COPY --from=builder /go/src/github.com/checkr/flagr/browser/flagr-ui/dist ./browser/flagr-ui/dist
 EXPOSE 18000
 CMD ./flagr


### PR DESCRIPTION
Use multi-stage build. Requires docker 17.09+.

The image size is down to 40mb. 