### PR TITLE
Fix postgres string scan bug

### DIFF
--- a/pkg/entity/flag_snapshot.go
+++ b/pkg/entity/flag_snapshot.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/jinzhu/gorm"
 	"github.com/sirupsen/logrus"
+	"github.com/spf13/cast"
 )
 
 // FlagSnapshot is the snapshot of a flag
@@ -26,14 +27,11 @@ func (f *Flag) Scan(value interface{}) error {
 	if value == nil {
 		return nil
 	}
-	if b, ok := value.([]byte); ok {
-		err := json.Unmarshal(b, f)
-		if err != nil {
-			return err
-		}
-		return nil
+	s := cast.ToString(value)
+	if err := json.Unmarshal([]byte(s), f); err != nil {
+		return fmt.Errorf("cannot scan %v into Flag type. err: %v", value, err)
 	}
-	return fmt.Errorf("Cannot scan %v into Flag type", value)
+	return nil
 }
 
 // Value implements valuer interface

--- a/pkg/entity/variant.go
+++ b/pkg/entity/variant.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/checkr/flagr/pkg/util"
 	"github.com/jinzhu/gorm"
+	"github.com/spf13/cast"
 )
 
 // Variant is the struct that represent the experience/variant of the evaluation entity
@@ -37,14 +38,11 @@ func (a *Attachment) Scan(value interface{}) error {
 	if value == nil {
 		return nil
 	}
-	if b, ok := value.([]byte); ok {
-		err := json.Unmarshal(b, a)
-		if err != nil {
-			return err
-		}
-		return nil
+	s := cast.ToString(value)
+	if err := json.Unmarshal([]byte(s), a); err != nil {
+		return fmt.Errorf("cannot scan %v into Attachment type. err: %v", value, err)
 	}
-	return fmt.Errorf("Cannot scan %v into Attachment type", value)
+	return nil
 }
 
 // Value implements valuer interface


### PR DESCRIPTION
Fix postgres string scan bug

## Description
The value scanned from postgres is actually with type `string`, not `[]byte`, thus the discrepancy between postgres and other databases.

## Motivation and Context
Fix #101 

## How Has This Been Tested?
Tested with postgres docker environment setup.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

