### PR TITLE
Use random entity id if it's nil

### DIFF
--- a/docs/api_docs/bundle.yaml
+++ b/docs/api_docs/bundle.yaml
@@ -968,13 +968,14 @@ definitions:
   evalContext:
     type: object
     required:
-      - entityID
       - entityType
       - flagID
     properties:
       entityID:
         type: string
-        minLength: 1
+        description: >-
+          entityID is used to deterministically at random to evaluate the flag
+          result. If it's empty, flagr will randomly generate one.
       entityType:
         type: string
         minLength: 1
@@ -1045,12 +1046,10 @@ definitions:
   evaluationEntity:
     type: object
     required:
-      - entityID
       - entityType
     properties:
       entityID:
         type: string
-        minLength: 1
       entityType:
         type: string
         minLength: 1

--- a/pkg/entity/distribution.go
+++ b/pkg/entity/distribution.go
@@ -46,8 +46,8 @@ type DistributionDebugLog struct {
 }
 
 // Rollout rolls out the entity based on the rolloutPercent
-func (d DistributionArray) Rollout(entityID *string, salt string, rolloutPercent uint) (variantID *uint, msg string) {
-	if entityID == nil || *entityID == "" {
+func (d DistributionArray) Rollout(entityID string, salt string, rolloutPercent uint) (variantID *uint, msg string) {
+	if entityID == "" {
 		return nil, "rollout no. empty entityID"
 	}
 
@@ -59,7 +59,7 @@ func (d DistributionArray) Rollout(entityID *string, salt string, rolloutPercent
 		return nil, "rollout no. there's no distribution set"
 	}
 
-	num := crc32Num(*entityID, salt)
+	num := crc32Num(entityID, salt)
 	vID, index := d.bucketByNum(num)
 	log := fmt.Sprintf("%+v", DistributionDebugLog{
 		BucketNum:         num,

--- a/pkg/entity/distribution_test.go
+++ b/pkg/entity/distribution_test.go
@@ -3,7 +3,6 @@ package entity
 import (
 	"testing"
 
-	"github.com/checkr/flagr/pkg/util"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -148,19 +147,19 @@ func TestRolloutWithEntity(t *testing.T) {
 		var vID *uint
 		var msg string
 
-		vID, msg = d.Rollout(nil, "salt", uint(0))
+		vID, msg = d.Rollout("", "salt", uint(0))
 		assert.Nil(t, vID)
 		assert.Contains(t, msg, "no")
 
-		vID, msg = d.Rollout(util.StringPtr("entity123"), "salt", uint(0))
+		vID, msg = d.Rollout("entity123", "salt", uint(0))
 		assert.Nil(t, vID)
 		assert.Contains(t, msg, "no")
 
-		vID, msg = d.Rollout(util.StringPtr("entity123"), "salt", uint(100))
+		vID, msg = d.Rollout("entity123", "salt", uint(100))
 		assert.NotNil(t, vID)
 		assert.Contains(t, msg, "yes")
 
-		vID, msg = d.Rollout(util.StringPtr("entity123"), "salt", uint(1))
+		vID, msg = d.Rollout("entity123", "salt", uint(1))
 		assert.Nil(t, vID)
 		assert.Contains(t, msg, "no")
 	})
@@ -173,7 +172,7 @@ func TestRolloutWithEntity(t *testing.T) {
 		var vID *uint
 		var msg string
 
-		vID, msg = d.Rollout(util.StringPtr("entity123"), "salt", uint(100))
+		vID, msg = d.Rollout("entity123", "salt", uint(100))
 		assert.Nil(t, vID)
 		assert.Contains(t, msg, "no")
 	})

--- a/pkg/handler/data_recorder_kafka_test.go
+++ b/pkg/handler/data_recorder_kafka_test.go
@@ -83,7 +83,7 @@ func TestKafkaEvalResult(t *testing.T) {
 		r := &kafkaEvalResult{
 			EvalResult: &models.EvalResult{
 				EvalContext: &models.EvalContext{
-					EntityID: util.StringPtr("123"),
+					EntityID: "123",
 				},
 				FlagID:         util.Int64Ptr(int64(1)),
 				FlagSnapshotID: 1,

--- a/pkg/handler/eval.go
+++ b/pkg/handler/eval.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"encoding/json"
 	"fmt"
+	"math/rand"
 	"time"
 
 	"github.com/checkr/flagr/pkg/config"
@@ -104,6 +105,10 @@ var evalFlag = func(evalContext models.EvalContext) *models.EvalResult {
 
 	if len(f.Segments) == 0 {
 		return BlankResult(f, evalContext, fmt.Sprintf("flagID %v has no segments", flagID))
+	}
+
+	if evalContext.EntityID == "" {
+		evalContext.EntityID = fmt.Sprintf("randomly_generated_%d", rand.Int31())
 	}
 
 	logs := []*models.SegmentDebugLog{}

--- a/pkg/handler/eval_test.go
+++ b/pkg/handler/eval_test.go
@@ -28,7 +28,7 @@ func TestEvalSegment(t *testing.T) {
 		vID, log := evalSegment(models.EvalContext{
 			EnableDebug:   true,
 			EntityContext: map[string]interface{}{"dl_state": "CA"},
-			EntityID:      util.StringPtr("entityID1"),
+			EntityID:      "entityID1",
 			EntityType:    util.StringPtr("entityType1"),
 			FlagID:        util.Int64Ptr(int64(100)),
 		}, s)
@@ -43,7 +43,7 @@ func TestEvalSegment(t *testing.T) {
 		vID, log := evalSegment(models.EvalContext{
 			EnableDebug:   true,
 			EntityContext: map[string]interface{}{},
-			EntityID:      util.StringPtr("entityID1"),
+			EntityID:      "entityID1",
 			EntityType:    util.StringPtr("entityType1"),
 			FlagID:        util.Int64Ptr(int64(100)),
 		}, s)
@@ -58,7 +58,7 @@ func TestEvalSegment(t *testing.T) {
 		vID, log := evalSegment(models.EvalContext{
 			EnableDebug:   true,
 			EntityContext: map[string]interface{}{"dl_state": "NY"},
-			EntityID:      util.StringPtr("entityID1"),
+			EntityID:      "entityID1",
 			EntityType:    util.StringPtr("entityType1"),
 			FlagID:        util.Int64Ptr(int64(100)),
 		}, s)
@@ -73,7 +73,7 @@ func TestEvalSegment(t *testing.T) {
 		vID, log := evalSegment(models.EvalContext{
 			EnableDebug:   true,
 			EntityContext: nil,
-			EntityID:      util.StringPtr("entityID1"),
+			EntityID:      "entityID1",
 			EntityType:    util.StringPtr("entityType1"),
 			FlagID:        util.Int64Ptr(int64(100)),
 		}, s)
@@ -88,8 +88,9 @@ func TestEvalFlag(t *testing.T) {
 
 	t.Run("test empty evalContext", func(t *testing.T) {
 		defer gostub.StubFunc(&GetEvalCache, GenFixtureEvalCache()).Reset()
-		result := evalFlag(models.EvalContext{})
+		result := evalFlag(models.EvalContext{FlagID: util.Int64Ptr(int64(100))})
 		assert.Nil(t, result.VariantID)
+		assert.NotEmpty(t, result.EvalContext.EntityID)
 	})
 
 	t.Run("test happy code path", func(t *testing.T) {
@@ -97,7 +98,7 @@ func TestEvalFlag(t *testing.T) {
 		result := evalFlag(models.EvalContext{
 			EnableDebug:   true,
 			EntityContext: map[string]interface{}{"dl_state": "CA"},
-			EntityID:      util.StringPtr("entityID1"),
+			EntityID:      "entityID1",
 			EntityType:    util.StringPtr("entityType1"),
 			FlagID:        util.Int64Ptr(int64(100)),
 		})
@@ -136,7 +137,7 @@ func TestEvalFlag(t *testing.T) {
 		result := evalFlag(models.EvalContext{
 			EnableDebug:   true,
 			EntityContext: map[string]interface{}{"dl_state": "CA", "state": "CA", "rate": 2000},
-			EntityID:      util.StringPtr("entityID1"),
+			EntityID:      "entityID1",
 			EntityType:    util.StringPtr("entityType1"),
 			FlagID:        util.Int64Ptr(int64(100)),
 		})
@@ -168,7 +169,7 @@ func TestEvalFlag(t *testing.T) {
 		result := evalFlag(models.EvalContext{
 			EnableDebug:   true,
 			EntityContext: map[string]interface{}{"dl_state": "CA", "state": "NY"},
-			EntityID:      util.StringPtr("entityID1"),
+			EntityID:      "entityID1",
 			EntityType:    util.StringPtr("entityType1"),
 			FlagID:        util.Int64Ptr(int64(100)),
 		})
@@ -184,7 +185,7 @@ func TestEvalFlag(t *testing.T) {
 		result := evalFlag(models.EvalContext{
 			EnableDebug:   true,
 			EntityContext: map[string]interface{}{"dl_state": "CA"},
-			EntityID:      util.StringPtr("entityID1"),
+			EntityID:      "entityID1",
 			EntityType:    util.StringPtr("entityType1"),
 			FlagID:        util.Int64Ptr(int64(100)),
 		})
@@ -208,7 +209,7 @@ func TestPostEvaluation(t *testing.T) {
 			Body: &models.EvalContext{
 				EnableDebug:   true,
 				EntityContext: map[string]interface{}{"dl_state": "CA", "state": "NY"},
-				EntityID:      util.StringPtr("entityID1"),
+				EntityID:      "entityID1",
 				EntityType:    util.StringPtr("entityType1"),
 				FlagID:        util.Int64Ptr(int64(100)),
 			},
@@ -227,7 +228,7 @@ func TestPostEvaluationBatch(t *testing.T) {
 				Entities: []*models.EvaluationEntity{
 					{
 						EntityContext: map[string]interface{}{"dl_state": "CA", "state": "NY"},
-						EntityID:      util.StringPtr("entityID1"),
+						EntityID:      "entityID1",
 						EntityType:    util.StringPtr("entityType1"),
 					},
 				},

--- a/swagger/index.yaml
+++ b/swagger/index.yaml
@@ -348,13 +348,12 @@ definitions:
   evalContext:
     type: object
     required:
-      - entityID
       - entityType
       - flagID
     properties:
       entityID:
         type: string
-        minLength: 1
+        description: entityID is used to deterministically at random to evaluate the flag result. If it's empty, flagr will randomly generate one.
       entityType:
         type: string
         minLength: 1
@@ -427,12 +426,10 @@ definitions:
   evaluationEntity:
     type: object
     required:
-      - entityID
       - entityType
     properties:
       entityID:
         type: string
-        minLength: 1
       entityType:
         type: string
         minLength: 1

--- a/swagger_gen/models/eval_context.go
+++ b/swagger_gen/models/eval_context.go
@@ -23,10 +23,8 @@ type EvalContext struct {
 	// entity context
 	EntityContext interface{} `json:"entityContext,omitempty"`
 
-	// entity ID
-	// Required: true
-	// Min Length: 1
-	EntityID *string `json:"entityID"`
+	// entityID is used to deterministically at random to evaluate the flag result. If it's empty, flagr will randomly generate one.
+	EntityID string `json:"entityID,omitempty"`
 
 	// entity type
 	// Required: true
@@ -43,11 +41,6 @@ type EvalContext struct {
 func (m *EvalContext) Validate(formats strfmt.Registry) error {
 	var res []error
 
-	if err := m.validateEntityID(formats); err != nil {
-		// prop
-		res = append(res, err)
-	}
-
 	if err := m.validateEntityType(formats); err != nil {
 		// prop
 		res = append(res, err)
@@ -61,19 +54,6 @@ func (m *EvalContext) Validate(formats strfmt.Registry) error {
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
-	return nil
-}
-
-func (m *EvalContext) validateEntityID(formats strfmt.Registry) error {
-
-	if err := validate.Required("entityID", "body", m.EntityID); err != nil {
-		return err
-	}
-
-	if err := validate.MinLength("entityID", "body", string(*m.EntityID), 1); err != nil {
-		return err
-	}
-
 	return nil
 }
 

--- a/swagger_gen/models/evaluation_entity.go
+++ b/swagger_gen/models/evaluation_entity.go
@@ -21,9 +21,7 @@ type EvaluationEntity struct {
 	EntityContext interface{} `json:"entityContext,omitempty"`
 
 	// entity ID
-	// Required: true
-	// Min Length: 1
-	EntityID *string `json:"entityID"`
+	EntityID string `json:"entityID,omitempty"`
 
 	// entity type
 	// Required: true
@@ -35,11 +33,6 @@ type EvaluationEntity struct {
 func (m *EvaluationEntity) Validate(formats strfmt.Registry) error {
 	var res []error
 
-	if err := m.validateEntityID(formats); err != nil {
-		// prop
-		res = append(res, err)
-	}
-
 	if err := m.validateEntityType(formats); err != nil {
 		// prop
 		res = append(res, err)
@@ -48,19 +41,6 @@ func (m *EvaluationEntity) Validate(formats strfmt.Registry) error {
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
-	return nil
-}
-
-func (m *EvaluationEntity) validateEntityID(formats strfmt.Registry) error {
-
-	if err := validate.Required("entityID", "body", m.EntityID); err != nil {
-		return err
-	}
-
-	if err := validate.MinLength("entityID", "body", string(*m.EntityID), 1); err != nil {
-		return err
-	}
-
 	return nil
 }
 

--- a/swagger_gen/restapi/embedded_spec.go
+++ b/swagger_gen/restapi/embedded_spec.go
@@ -1163,7 +1163,6 @@ func init() {
     "evalContext": {
       "type": "object",
       "required": [
-        "entityID",
         "entityType",
         "flagID"
       ],
@@ -1175,8 +1174,8 @@ func init() {
           "type": "object"
         },
         "entityID": {
-          "type": "string",
-          "minLength": 1
+          "description": "entityID is used to deterministically at random to evaluate the flag result. If it's empty, flagr will randomly generate one.",
+          "type": "string"
         },
         "entityType": {
           "type": "string",
@@ -1298,7 +1297,6 @@ func init() {
     "evaluationEntity": {
       "type": "object",
       "required": [
-        "entityID",
         "entityType"
       ],
       "properties": {
@@ -1306,8 +1304,7 @@ func init() {
           "type": "object"
         },
         "entityID": {
-          "type": "string",
-          "minLength": 1
+          "type": "string"
         },
         "entityType": {
           "type": "string",
@@ -2742,7 +2739,6 @@ func init() {
     "evalContext": {
       "type": "object",
       "required": [
-        "entityID",
         "entityType",
         "flagID"
       ],
@@ -2754,8 +2750,8 @@ func init() {
           "type": "object"
         },
         "entityID": {
-          "type": "string",
-          "minLength": 1
+          "description": "entityID is used to deterministically at random to evaluate the flag result. If it's empty, flagr will randomly generate one.",
+          "type": "string"
         },
         "entityType": {
           "type": "string",
@@ -2877,7 +2873,6 @@ func init() {
     "evaluationEntity": {
       "type": "object",
       "required": [
-        "entityID",
         "entityType"
       ],
       "properties": {
@@ -2885,8 +2880,7 @@ func init() {
           "type": "object"
         },
         "entityID": {
-          "type": "string",
-          "minLength": 1
+          "type": "string"
         },
         "entityType": {
           "type": "string",


### PR DESCRIPTION


## Description
If `entity_id` is null or empty, flagr will randomly generate one.

## Motivation and Context
Reduce the number of unexpected 422 errors. And also it's convenient for the use case that entity_id is not readily available

## How Has This Been Tested?
Unit test and local integration tests.

## Types of changes
- [x] New feature (non-breaking change which adds functionality)
