### PR TITLE
Add db connection debugging logging env

### DIFF
--- a/pkg/config/env.go
+++ b/pkg/config/env.go
@@ -39,6 +39,9 @@ var Config = struct {
 	// mysql:    "root:@tcp(127.0.0.1:18100)/flagr?parseTime=true"
 	// postgres: "host=myhost user=root dbname=flagr password=mypassword"
 	DBConnectionStr string `env:"FLAGR_DB_DBCONNECTIONSTR" envDefault:"flagr.sqlite"`
+	// DBConnectionDebug controls whether to show the database connection debugging logs
+	// warning: it may log the credentials to the stdout
+	DBConnectionDebug bool `env:"FLAGR_DB_DBCONNECTION_DEBUG" envDefault:"true"`
 
 	// CORSEnabled - enable CORS
 	CORSEnabled bool `env:"FLAGR_CORS_ENABLED" envDefault:"true"`

--- a/pkg/repo/db.go
+++ b/pkg/repo/db.go
@@ -23,7 +23,11 @@ func GetDB() *gorm.DB {
 	singletonOnce.Do(func() {
 		db, err := gorm.Open(config.Config.DBDriver, config.Config.DBConnectionStr)
 		if err != nil {
-			logrus.WithField("err", err).Fatal("failed to connect to db")
+			if config.Config.DBConnectionDebug {
+				logrus.WithField("err", err).Fatal("failed to connect to db")
+			} else {
+				logrus.Fatal("failed to connect to db")
+			}
 		}
 		db.SetLogger(logrus.StandardLogger())
 		db.AutoMigrate(entity.AutoMigrateTables...)


### PR DESCRIPTION
Since the database connection error may contain credentials, we are adding this env to control whether we should log that error or not.