### PR TITLE
Fix typo in flagr overview docs

### DIFF
--- a/docs/flagr_overview.md
+++ b/docs/flagr_overview.md
@@ -5,7 +5,7 @@
 The definitions of the following concepts are in [API doc](https://checkr.github.io/flagr/api_docs).
 
 - **Flag**. It can be a feature flag, an experiment, or a configuration.
-- **Variant** represents the possible variantion of a flag. For example, control/treatment, green/yellow/red, etc.
+- **Variant** represents the possible variation of a flag. For example, control/treatment, green/yellow/red, etc.
 - **Variant Attachment** represents the dynamic configuration of a variant. For example, if you have a variant for the `green` button, you can dynamically control what's the hex color of green you want to use (e.g. `{"hex_color": "#42b983"}`).
 - **Segment** represents the segmentation, i.e. the set of audience we want to target. Segment is the smallest unit of a component we can analyze in Flagr Metrics.
 - **Constraint** represents rules that we can use to define the audience of the segment. In other words, the audience in the segment is defined by a set of constraints. Specifically, in Flagr, the constraints are connected with `AND` in a segment.


### PR DESCRIPTION
Noticed a typo:

`variantion` -> `variation`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.