### PR TITLE
Fix InsecureVerifySSL config

### DIFF
--- a/pkg/handler/data_recorder_kafka.go
+++ b/pkg/handler/data_recorder_kafka.go
@@ -40,7 +40,7 @@ func createTLSConfiguration(certFile string, keyFile string, caFile string, veri
 		t = &tls.Config{
 			Certificates:       []tls.Certificate{cert},
 			RootCAs:            caCertPool,
-			InsecureSkipVerify: verifySSL,
+			InsecureSkipVerify: !verifySSL,
 		}
 	}
 	// will be nil by default if nothing is provided


### PR DESCRIPTION
From the definition of `InsecureSkipVerify`:

```
// InsecureSkipVerify controls whether a client verifies the     
// server's certificate chain and host name.                     
// If InsecureSkipVerify is true, TLS accepts any certificate    
// presented by the server and any host name in that certificate.
// In this mode, TLS is susceptible to man-in-the-middle attacks.
// This should be used only for testing.                         
```