### PR TITLE
Use pointer cursor for flags table rows

### DIFF
--- a/browser/flagr-ui/src/components/Flags.vue
+++ b/browser/flagr-ui/src/components/Flags.vue
@@ -155,6 +155,9 @@ export default {
   .el-table {
     margin-top: 2em;
   }
+  .el-table__row {
+    cursor: pointer;
+  }
 }
 
 </style>


### PR DESCRIPTION
## Description
It looks a bit weird to not have the pointer cursor when clicking on objects that lead to actins or other pages.

For this case, clicking anywhere in the TR element, leads you to edit that flag.

## Motivation and Context
UX


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] ~My change requires a change to the documentation.~
- [ ] ~I have updated the documentation accordingly.~
- [ ] ~I have added tests to cover my changes.~
- [x] All new and existing tests passed.

