### PR TITLE
Added config for base path for web UI

### DIFF
--- a/pkg/config/env.go
+++ b/pkg/config/env.go
@@ -120,4 +120,7 @@ var Config = struct {
 
 	// "HS256" and "RS256" supported
 	JWTAuthSigningMethod string `env:"FLAGR_JWT_AUTH_SIGNING_METHOD" envDefault:"HS256"`
+
+	// WebPrefix - base path for web
+	WebPrefix string `env:"FLAGR_WEB_PREFIX" envDefault:""`
 }{}

--- a/pkg/config/middleware.go
+++ b/pkg/config/middleware.go
@@ -54,7 +54,11 @@ func SetupGlobalMiddleware(handler http.Handler) http.Handler {
 		n.Use(negronilogrus.NewMiddlewareFromLogger(logrus.StandardLogger(), "flagr"))
 	}
 
-	n.Use(negroni.NewStatic(http.Dir("./browser/flagr-ui/dist/")))
+	n.Use(&negroni.Static{
+		Dir:       http.Dir("./browser/flagr-ui/dist/"),
+		Prefix:    Config.WebPrefix,
+		IndexFile: "index.html",
+	})
 
 	if Config.PProfEnabled {
 		n.UseHandler(pprof.New()(handler))


### PR DESCRIPTION
## Description
Added `FLAGR_WEB_PREFIX` env so it is possible to serve the static web UI from another path different to `/`

## Motivation and Context

For example, if deploying flagger in ECS behind and ELB it wouldn't be possible to deploy Flagr anywhere but in the `/*` listener since the Web UI is served in `/` and the API in `/api/v1`, this would allow to server the UI from `/web/flagr/*` for example.

## How Has This Been Tested?
Built the code in a docker image, set the environment variable to `/web/flagr` and the UI was loading from that prefix

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [?] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [?] All new and existing tests passed.