### PR TITLE
Allow uppercase letters in flag keys

### DIFF
--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -12,9 +12,8 @@ import (
 
 var (
 	keyLengthLimit = 63
-	keyRegex       = regexp.MustCompile("^[a-z]+[a-z0-9_]*$")
+	keyRegex       = regexp.MustCompile("(?i)^[a-z0-9_]+$")
 
-	randomKeyCharset = []byte("123456789abcdefghijkmnopqrstuvwxyz")
 	randomKeyPrefix  = "k"
 )
 
@@ -31,7 +30,7 @@ func IsSafeKey(s string) (bool, string) {
 
 // NewSecureRandomKey creates a new secure random key
 func NewSecureRandomKey() string {
-	return randomKeyPrefix + uniuri.NewLenChars(uniuri.StdLen, randomKeyCharset)
+	return randomKeyPrefix + uniuri.New()
 }
 
 // SafeString safely cast to string


### PR DESCRIPTION
Flag keys may now allow uppercase letters.

## Description
This PR allows Flag keys to be alphanumeric & case insensitive as well as include underscores. It does remove the constraint of having at least one lowercase letter as the first character.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The first FLAG in the [Flagr demo](https://try-flagr.herokuapp.com) had a flag key (e.g. `kppaP9af9x10`) which had an uppercase letter which threw an error when I tried to change the description because of the capital letters in the flag key. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.