### PR TITLE
Add UI env for entity types override

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,23 @@
+######################################
+# Prepare yarn and go build in builder
+######################################
 FROM checkr/flagr-ci as builder
 WORKDIR /go/src/github.com/checkr/flagr
 ADD . .
+
+# Build UI
+# FLAGR_UI_POSSIBLE_ENTITY_TYPES is useful for limiting the choices of entity types
+ARG FLAGR_UI_POSSIBLE_ENTITY_TYPES=null
+ENV FLAGR_UI_POSSIBLE_ENTITY_TYPES ${FLAGR_UI_POSSIBLE_ENTITY_TYPES}
 RUN cd ./browser/flagr-ui/ && yarn install && yarn run build
+
+# Build Go server
 RUN make build
 
 
-
+######################################
+# Copy from builder to alpine image
+######################################
 FROM alpine:3.6
 RUN apk add --no-cache libc6-compat ca-certificates curl
 WORKDIR /go/src/github.com/checkr/flagr

--- a/browser/flagr-ui/config/prod.env.js
+++ b/browser/flagr-ui/config/prod.env.js
@@ -1,4 +1,9 @@
 module.exports = {
   NODE_ENV: '"production"',
-  API_URL: '"/api/v1"'
+  API_URL: '"/api/v1"',
+
+  // ',' separated string
+  // For example
+  // FLAGR_UI_POSSIBLE_ENTITY_TYPES=report_int_id,account_int_id
+  FLAGR_UI_POSSIBLE_ENTITY_TYPES: process.env.FLAGR_UI_POSSIBLE_ENTITY_TYPES
 }

--- a/browser/flagr-ui/src/components/Flag.vue
+++ b/browser/flagr-ui/src/components/Flag.vue
@@ -176,7 +176,7 @@
                           v-model="flag.entityType"
                           size="mini"
                           filterable
-                          allow-create
+                          :allow-create="allowCreateEntityType"
                           default-first-option
                           placeholder="<null>">
                           <el-option
@@ -551,6 +551,7 @@ export default {
       dialogEditDistributionOpen: false,
       dialogCreateSegmentOpen: false,
       entityTypes: [],
+      allowCreateEntityType: true,
       flag: {
         createdBy: '',
         dataRecordsEnabled: false,
@@ -774,16 +775,29 @@ export default {
         this.flag = flag
         this.loaded = true
       }, handleErr.bind(this))
-
-      Axios.get(`${API_URL}/flags/entity_types`).then(response => {
-        let arr = response.data.map(key => {
+      this.fetchEntityTypes()
+    },
+    fetchEntityTypes () {
+      function prepareEntityTypes (entityTypes) {
+        let arr = entityTypes.map(key => {
           let label = key === '' ? '<null>' : key
           return {'label': label, 'value': key}
         })
-        if (response.data.indexOf('') === -1) {
+        if (entityTypes.indexOf('') === -1) {
           arr.unshift({label: '<null>', value: ''})
         }
-        this.entityTypes = arr
+        return arr
+      }
+
+      if (process.env.FLAGR_UI_POSSIBLE_ENTITY_TYPES) {
+        let entityTypes = process.env.FLAGR_UI_POSSIBLE_ENTITY_TYPES.split(',')
+        this.entityTypes = prepareEntityTypes(entityTypes)
+        this.allowCreateEntityType = false
+        return
+      }
+
+      Axios.get(`${API_URL}/flags/entity_types`).then(response => {
+        this.entityTypes = prepareEntityTypes(response.data)
       }, handleErr.bind(this))
     }
   },


### PR DESCRIPTION

## Description
Use `FLAGR_UI_POSSIBLE_ENTITY_TYPES` as build arg for UI, by default it's `null`, which means it doesn't imply any restrictions.

## Motivation and Context
To limit the choices and normalize entity types for better data analytics

## How Has This Been Tested?
Tested locally and with docker build-arg

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

