### PR TITLE
Fix mysql query

### DIFF
--- a/pkg/handler/crud.go
+++ b/pkg/handler/crud.go
@@ -173,7 +173,7 @@ func (c *crud) GetFlagSnapshots(params flag.GetFlagSnapshotsParams) middleware.R
 
 func (c *crud) GetFlagEntityTypes(params flag.GetFlagEntityTypesParams) middleware.Responder {
 	entityTypes := []entity.FlagEntityType{}
-	if err := getDB().Order("key ASC").Find(&entityTypes).Error; err != nil {
+	if err := entity.NewFlagEntityTypeQuerySet(getDB()).All(&entityTypes); err != nil {
 		return flag.NewGetFlagEntityTypesDefault(500).WithPayload(
 			ErrorMessage("cannot find flag entity types. err:%s", err))
 


### PR DESCRIPTION
Fix error

```
{
"message": "cannot find flag entity types. err:Error 1064: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'key ASC' at line 1"
}
```

Looks like `Order("key ASC")` was not supported in gorm to mysql driver. Since we don't really care about the orders, so just a queryset query is enough