### PR TITLE
Reorder middlewares and add test for must parse kafka version

### DIFF
--- a/pkg/handler/data_recorder_kafka.go
+++ b/pkg/handler/data_recorder_kafka.go
@@ -23,8 +23,8 @@ var (
 	saramaNewAsyncProducer = sarama.NewAsyncProducer
 )
 
-func mustParseKafkaVersion() sarama.KafkaVersion {
-	v, err := sarama.ParseKafkaVersion(config.Config.RecorderKafkaVersion)
+func mustParseKafkaVersion(version string) sarama.KafkaVersion {
+	v, err := sarama.ParseKafkaVersion(version)
 	if err != nil {
 		panic(err)
 	}
@@ -47,7 +47,7 @@ var NewKafkaRecorder = func() DataRecorder {
 	cfg.Producer.RequiredAcks = sarama.WaitForLocal
 	cfg.Producer.Retry.Max = config.Config.RecorderKafkaRetryMax
 	cfg.Producer.Flush.Frequency = config.Config.RecorderKafkaFlushFrequency
-	cfg.Version = mustParseKafkaVersion()
+	cfg.Version = mustParseKafkaVersion(config.Config.RecorderKafkaVersion)
 
 	brokerList := strings.Split(config.Config.RecorderKafkaBrokers, ",")
 	producer, err := saramaNewAsyncProducer(brokerList, cfg)

--- a/pkg/handler/data_recorder_kafka_test.go
+++ b/pkg/handler/data_recorder_kafka_test.go
@@ -157,3 +157,14 @@ func TestAsyncRecord(t *testing.T) {
 		assert.NotNil(t, r)
 	})
 }
+
+func TestMustParseKafkaVersion(t *testing.T) {
+	assert.NotPanics(t, func() {
+		mustParseKafkaVersion("0.8.2.0")
+		mustParseKafkaVersion("1.1.0") // for version >1.0, use 3 numbers
+	})
+
+	assert.Panics(t, func() {
+		mustParseKafkaVersion("1.1.0.0") // for version >1.0, use 3 numbers
+	})
+}


### PR DESCRIPTION
Reorder the middleware so that other stats logging can catch recovery middleware.

- Move recovery middleware closer to the application code
- Use logrus for recovery middleware logging, so that it can catch recovery error in sentry
- Add tests for `mustParseKafkaVersion`