### PR TITLE
Add preload param in get /flags

### DIFF
--- a/docs/api_docs/bundle.yaml
+++ b/docs/api_docs/bundle.yaml
@@ -79,6 +79,10 @@ paths:
           description: >-
             return flags given the offset, it should usually set together with
             limit
+        - in: query
+          name: preload
+          type: boolean
+          description: return flags with preloaded segments and variants
       responses:
         '200':
           description: list all the flags

--- a/integration_tests/test.sh
+++ b/integration_tests/test.sh
@@ -283,6 +283,34 @@ step_7_test_evaluation()
         matches "\"segmentID\":2"
 }
 
+step_8_test_preload()
+{
+    flagr_url=$1:18000/api/v1
+    sleep 5
+
+    ################################################
+    # Test preload for /flags (depends on ?preload=true/false
+    ################################################
+    shakedown GET $flagr_url/flags
+        status 200
+        matches "\"variants\":\[\]"
+        matches "\"segments\":\[\]"
+
+    shakedown GET $flagr_url/flags?preload=true
+        status 200
+        matches "\"variantKey\":\"key_1\""
+        matches "\"variantID\":1"
+
+    ################################################
+    # Test preload for /flag
+    # always preload for getting a single flag
+    ################################################
+    shakedown GET $flagr_url/flags/1
+        status 200
+        matches "\"variantKey\":\"key_1\""
+        matches "\"variantID\":1"
+}
+
 
 start_test()
 {
@@ -301,6 +329,7 @@ start_test()
     step_5_test_crud_variant $flagr_host
     step_6_test_crud_distribution $flagr_host
     step_7_test_evaluation $flagr_host
+    step_8_test_preload $flagr_host
 }
 
 start(){

--- a/pkg/entity/segment.go
+++ b/pkg/entity/segment.go
@@ -22,24 +22,21 @@ type Segment struct {
 	SegmentEvaluation SegmentEvaluation `gorm:"-" json:"-"`
 }
 
+// PreloadConstraintsDistribution preloads constraints and distributions
+// for segment
+func PreloadConstraintsDistribution(db *gorm.DB) *gorm.DB {
+	return db.
+		Preload("Distributions", func(db *gorm.DB) *gorm.DB {
+			return db.Order("variant_id ASC")
+		}).
+		Preload("Constraints", func(db *gorm.DB) *gorm.DB {
+			return db.Order("created_at ASC")
+		})
+}
+
 // Preload preloads the segment
 func (s *Segment) Preload(db *gorm.DB) error {
-	cs := []Constraint{}
-	err := db.Order("created_at").Where(Constraint{SegmentID: s.ID}).Find(&cs).Error
-
-	if err != nil {
-		return err
-	}
-	s.Constraints = cs
-
-	ds := []Distribution{}
-	err = db.Order("variant_id").Where(Distribution{SegmentID: s.ID}).Find(&ds).Error
-	if err != nil {
-		return err
-	}
-	s.Distributions = ds
-
-	return nil
+	return PreloadConstraintsDistribution(db).First(s, s.ID).Error
 }
 
 // SegmentEvaluation is a struct that holds the necessary info for evaluation

--- a/pkg/handler/eval_cache.go
+++ b/pkg/handler/eval_cache.go
@@ -7,7 +7,6 @@ import (
 	"github.com/checkr/flagr/pkg/config"
 	"github.com/checkr/flagr/pkg/entity"
 	"github.com/checkr/flagr/pkg/util"
-	"github.com/jinzhu/gorm"
 	"github.com/sirupsen/logrus"
 )
 
@@ -66,16 +65,7 @@ var fetchAllFlags = func() ([]entity.Flag, error) {
 	// Use eager loading to avoid N+1 problem
 	// doc: http://jinzhu.me/gorm/crud.html#preloading-eager-loading
 	fs := []entity.Flag{}
-	err := getDB().
-		Preload("Segments", func(db *gorm.DB) *gorm.DB {
-			return db.
-				Preload("Distributions", func(db *gorm.DB) *gorm.DB { return db.Order("variant_id ASC") }).
-				Preload("Constraints", func(db *gorm.DB) *gorm.DB { return db.Order("created_at ASC") }).
-				Order("rank ASC").
-				Order("id ASC")
-		}).
-		Preload("Variants").
-		Find(&fs).Error
+	err := entity.PreloadSegmentsVariants(getDB()).Find(&fs).Error
 	return fs, err
 }
 

--- a/pkg/mapper/entity_restapi/e2r/e2r.go
+++ b/pkg/mapper/entity_restapi/e2r/e2r.go
@@ -11,10 +11,8 @@ import (
 	"github.com/checkr/flagr/swagger_gen/models"
 )
 
-var getDB = entity.GetDB
-
 // MapFlag maps flag
-func MapFlag(e *entity.Flag, preload bool) (*models.Flag, error) {
+func MapFlag(e *entity.Flag) (*models.Flag, error) {
 	r := &models.Flag{}
 	r.ID = int64(e.ID)
 	r.Key = e.Key
@@ -25,15 +23,7 @@ func MapFlag(e *entity.Flag, preload bool) (*models.Flag, error) {
 	r.Enabled = util.BoolPtr(e.Enabled)
 	r.UpdatedAt = strfmt.DateTime(e.UpdatedAt)
 	r.UpdatedBy = e.UpdatedBy
-
-	if preload {
-		if err := e.Preload(getDB()); err != nil {
-			return nil, err
-		}
-	}
-
-	// preloaded fields
-	r.Segments = MapSegments(e.Segments, preload)
+	r.Segments = MapSegments(e.Segments)
 	r.Variants = MapVariants(e.Variants)
 
 	return r, nil
@@ -43,7 +33,7 @@ func MapFlag(e *entity.Flag, preload bool) (*models.Flag, error) {
 func MapFlags(e []entity.Flag) ([]*models.Flag, error) {
 	ret := make([]*models.Flag, len(e), len(e))
 	for i, f := range e {
-		rf, err := MapFlag(&f, false)
+		rf, err := MapFlag(&f)
 		if err != nil {
 			return nil, err
 		}
@@ -58,7 +48,7 @@ func MapFlagSnapshot(e *entity.FlagSnapshot) (*models.FlagSnapshot, error) {
 	if err := json.Unmarshal(e.Flag, ef); err != nil {
 		return nil, err
 	}
-	f, err := MapFlag(ef, false)
+	f, err := MapFlag(ef)
 	if err != nil {
 		return nil, err
 	}
@@ -85,11 +75,7 @@ func MapFlagSnapshots(e []entity.FlagSnapshot) ([]*models.FlagSnapshot, error) {
 }
 
 // MapSegment maps segment
-func MapSegment(e *entity.Segment, preload bool) *models.Segment {
-	if preload {
-		e.Preload(getDB())
-	}
-
+func MapSegment(e *entity.Segment) *models.Segment {
 	r := &models.Segment{}
 	r.ID = int64(e.ID)
 	r.Description = util.StringPtr(e.Description)
@@ -101,10 +87,10 @@ func MapSegment(e *entity.Segment, preload bool) *models.Segment {
 }
 
 // MapSegments maps segments
-func MapSegments(e []entity.Segment, preload bool) []*models.Segment {
+func MapSegments(e []entity.Segment) []*models.Segment {
 	ret := make([]*models.Segment, len(e), len(e))
 	for i, s := range e {
-		ret[i] = MapSegment(&s, preload)
+		ret[i] = MapSegment(&s)
 	}
 	return ret
 }

--- a/swagger/flags.yaml
+++ b/swagger/flags.yaml
@@ -29,6 +29,10 @@ get:
       type: integer
       format: int64
       description: return flags given the offset, it should usually set together with limit
+    - in: query
+      name: preload
+      type: boolean
+      description: return flags with preloaded segments and variants
   responses:
     200:
       description: list all the flags

--- a/swagger_gen/restapi/embedded_spec.go
+++ b/swagger_gen/restapi/embedded_spec.go
@@ -171,6 +171,12 @@ func init() {
             "description": "return flags given the offset, it should usually set together with limit",
             "name": "offset",
             "in": "query"
+          },
+          {
+            "type": "boolean",
+            "description": "return flags with preloaded segments and variants",
+            "name": "preload",
+            "in": "query"
           }
         ],
         "responses": {
@@ -1912,6 +1918,12 @@ func init() {
             "format": "int64",
             "description": "return flags given the offset, it should usually set together with limit",
             "name": "offset",
+            "in": "query"
+          },
+          {
+            "type": "boolean",
+            "description": "return flags with preloaded segments and variants",
+            "name": "preload",
             "in": "query"
           }
         ],

--- a/swagger_gen/restapi/operations/flag/find_flags_parameters.go
+++ b/swagger_gen/restapi/operations/flag/find_flags_parameters.go
@@ -56,6 +56,10 @@ type FindFlagsParams struct {
 	  In: query
 	*/
 	Offset *int64
+	/*return flags with preloaded segments and variants
+	  In: query
+	*/
+	Preload *bool
 }
 
 // BindRequest both binds and validates a request, it assumes that complex things implement a Validatable(strfmt.Registry) error interface
@@ -96,6 +100,11 @@ func (o *FindFlagsParams) BindRequest(r *http.Request, route *middleware.Matched
 
 	qOffset, qhkOffset, _ := qs.GetOK("offset")
 	if err := o.bindOffset(qOffset, qhkOffset, route.Formats); err != nil {
+		res = append(res, err)
+	}
+
+	qPreload, qhkPreload, _ := qs.GetOK("preload")
+	if err := o.bindPreload(qPreload, qhkPreload, route.Formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -221,6 +230,28 @@ func (o *FindFlagsParams) bindOffset(rawData []string, hasKey bool, formats strf
 		return errors.InvalidType("offset", "query", "int64", raw)
 	}
 	o.Offset = &value
+
+	return nil
+}
+
+// bindPreload binds and validates parameter Preload from query.
+func (o *FindFlagsParams) bindPreload(rawData []string, hasKey bool, formats strfmt.Registry) error {
+	var raw string
+	if len(rawData) > 0 {
+		raw = rawData[len(rawData)-1]
+	}
+
+	// Required: false
+	// AllowEmptyValue: false
+	if raw == "" { // empty values pass all other validations
+		return nil
+	}
+
+	value, err := swag.ConvertBool(raw)
+	if err != nil {
+		return errors.InvalidType("preload", "query", "bool", raw)
+	}
+	o.Preload = &value
 
 	return nil
 }

--- a/swagger_gen/restapi/operations/flag/find_flags_urlbuilder.go
+++ b/swagger_gen/restapi/operations/flag/find_flags_urlbuilder.go
@@ -21,6 +21,7 @@ type FindFlagsURL struct {
 	Key             *string
 	Limit           *int64
 	Offset          *int64
+	Preload         *bool
 
 	_basePath string
 	// avoid unkeyed usage
@@ -102,6 +103,14 @@ func (o *FindFlagsURL) Build() (*url.URL, error) {
 	}
 	if offset != "" {
 		qs.Set("offset", offset)
+	}
+
+	var preload string
+	if o.Preload != nil {
+		preload = swag.FormatBool(*o.Preload)
+	}
+	if preload != "" {
+		qs.Set("preload", preload)
 	}
 
 	result.RawQuery = qs.Encode()


### PR DESCRIPTION
## Description
Add preload query param in `GET /flags`. Fix #199 

- `GET /flags?preload=true` to get all the segments and variants together with the flags.
- Refactor the existing code of preloading for both flags (+segments +variants) and segments (+constraints +distributions)
- Simplify how we do the mapper of entity-to-restapi (e2r), removed the param of preload flag, and let its upstream call preload function before the mapper

## How Has This Been Tested?
- [x] unit tests
- [x] integration tests
- [x] manual UI tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.