### PR TITLE
Fix empty response when flag was deleted

### DIFF
--- a/pkg/handler/eval.go
+++ b/pkg/handler/eval.go
@@ -11,6 +11,7 @@ import (
 	"github.com/checkr/flagr/pkg/util"
 	"github.com/checkr/flagr/swagger_gen/models"
 	"github.com/checkr/flagr/swagger_gen/restapi/operations/evaluation"
+	"github.com/jinzhu/gorm"
 
 	"github.com/bsm/ratelimit"
 	"github.com/davecgh/go-spew/spew"
@@ -116,7 +117,8 @@ var evalFlag = func(evalContext models.EvalContext) *models.EvalResult {
 	}
 
 	if f == nil {
-		return BlankResult(nil, evalContext, fmt.Sprintf("flagID %v not found", flagID))
+		emptyFlag := &entity.Flag{Model: gorm.Model{ID: flagID}, Key: flagKey}
+		return BlankResult(emptyFlag, evalContext, fmt.Sprintf("flagID %v not found or deleted", flagID))
 	}
 
 	if !f.Enabled {

--- a/pkg/handler/eval_test.go
+++ b/pkg/handler/eval_test.go
@@ -95,6 +95,7 @@ func TestEvalFlag(t *testing.T) {
 		defer gostub.StubFunc(&GetEvalCache, GenFixtureEvalCache()).Reset()
 		result := evalFlag(models.EvalContext{FlagID: int64(100)})
 		assert.Nil(t, result.VariantID)
+		assert.NotZero(t, result.FlagID)
 		assert.NotEmpty(t, result.EvalContext.EntityID)
 	})
 


### PR DESCRIPTION
Some old clients are validating flag_id in the response. If a flag was deleted, the response should still pass the `flag_id >= 1` validation rule defined in swagger.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
unit tests and integration tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.