### PR TITLE
Use relative assetsPublicPath

### DIFF
--- a/browser/flagr-ui/config/index.js
+++ b/browser/flagr-ui/config/index.js
@@ -7,7 +7,7 @@ module.exports = {
     index: path.resolve(__dirname, '../dist/index.html'),
     assetsRoot: path.resolve(__dirname, '../dist'),
     assetsSubDirectory: 'static',
-    assetsPublicPath: '/',
+    assetsPublicPath: '',
     productionSourceMap: true,
     // Gzip off by default as many popular static hosts such as
     // Surge or Netlify already gzip all static assets for you.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
assetsPublicPath needs to be relative, so that it can work with `FLAGR_WEB_PREFIX='/foo'`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
tested locally with and without the `FLAGR_WEB_PREFIX` setting.

```
FLAGR_WEB_PREFIX='/foo' make run
```
![image](https://user-images.githubusercontent.com/658840/53276092-89790880-36b2-11e9-819f-7bab5400d7d1.png)




```
make run
```
![image](https://user-images.githubusercontent.com/658840/53276117-a01f5f80-36b2-11e9-8261-aa511703b87b.png)




## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.