### PR TITLE
Use English as default locale for flagr instead of Chinese

### DIFF
--- a/browser/flagr-ui/src/main.js
+++ b/browser/flagr-ui/src/main.js
@@ -3,13 +3,14 @@
 import Vue from 'vue'
 
 import ElementUI from 'element-ui'
+import locale from 'element-ui/lib/locale/lang/en'
 import 'element-ui/lib/theme-chalk/index.css'
 
 import App from './App'
 import router from './router'
 
 Vue.config.productionTip = false
-Vue.use(ElementUI)
+Vue.use(ElementUI, { locale })
 
 /* eslint-disable no-new */
 


### PR DESCRIPTION
## Description
As the contents for flagr is in English, set the default locale for
ElementUI to English (instead of defaulting to Chinese).  This is to
prevent certain contents from being displayed in Chinese.  eg. when
there are no flags available.

## Motivation and Context
Keep the language consistent in the application.

## How Has This Been Tested?
Launch the default flagr and run it using docker:

Before the change, confirm that the bug is present by launching a docker container as such:
```
docker run -p 18000:18000 checkr/flagr
```

Visit the GUI and delete all flags.  You will see `No Data` in Chinese written as `暂无数据`.

Test the change and launch a docker container with the change.  You will see `No Data`.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.