### PR TITLE
Use web prefix for main API

### DIFF
--- a/browser/flagr-ui/config/prod.env.js
+++ b/browser/flagr-ui/config/prod.env.js
@@ -1,6 +1,6 @@
 module.exports = {
   NODE_ENV: '"production"',
-  API_URL: '"/api/v1"',
+  API_URL: '"api/v1"',
 
   // ',' separated string
   // For example

--- a/pkg/config/env.go
+++ b/pkg/config/env.go
@@ -145,6 +145,9 @@ var Config = struct {
 	// "HS256" and "RS256" supported
 	JWTAuthSigningMethod string `env:"FLAGR_JWT_AUTH_SIGNING_METHOD" envDefault:"HS256"`
 
-	// WebPrefix - base path for web
+	// WebPrefix - base path for web and API
+	// e.g. FLAGR_WEB_PREFIX=/foo
+	// UI path  => localhost:18000/foo"
+	// API path => localhost:18000/foo/api/v1"
 	WebPrefix string `env:"FLAGR_WEB_PREFIX" envDefault:""`
 }{}

--- a/pkg/config/middleware.go
+++ b/pkg/config/middleware.go
@@ -86,6 +86,10 @@ func SetupGlobalMiddleware(handler http.Handler) http.Handler {
 
 	n.Use(setupRecoveryMiddleware())
 
+	if Config.WebPrefix != "" {
+		handler = http.StripPrefix(Config.WebPrefix, handler)
+	}
+
 	if Config.PProfEnabled {
 		n.UseHandler(pprof.New()(handler))
 	} else {


### PR DESCRIPTION


## Description
Fix #225. Context is that UI's api path can be relative, and we can also prefix our main api with `FLAGR_WEB_PREFIX`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Tested locally with and without `FLAGR_WEB_PREFIX`

### FLAGR_WEB_PREFIX='/foo' make run
![image](https://user-images.githubusercontent.com/658840/54064454-47c78200-41c9-11e9-86ae-237d1c8d8b1c.png)

### make run
![image](https://user-images.githubusercontent.com/658840/54064466-63cb2380-41c9-11e9-86a6-f755c7b9fff9.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

Although breaking changes to the behavior of FLAGR_WEB_PREFIX, but the scope should be small, since it only applies to deployment after https://github.com/checkr/flagr/issues/222

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.