### PR TITLE
Remove required fields from evalResult swagger model

### DIFF
--- a/docs/api_docs/bundle.yaml
+++ b/docs/api_docs/bundle.yaml
@@ -1105,20 +1105,10 @@ definitions:
         type: string
   evalResult:
     type: object
-    required:
-      - flagID
-      - flagKey
-      - segmentID
-      - variantID
-      - variantKey
-      - variantAttachment
-      - evalContext
-      - timestamp
     properties:
       flagID:
         type: integer
         format: int64
-        minimum: 1
       flagKey:
         type: string
       flagSnapshotID:
@@ -1127,21 +1117,17 @@ definitions:
       segmentID:
         type: integer
         format: int64
-        minimum: 1
       variantID:
         type: integer
         format: int64
-        minimum: 1
       variantKey:
         type: string
-        minLength: 1
       variantAttachment:
         type: object
       evalContext:
         $ref: '#/definitions/evalContext'
       timestamp:
         type: string
-        minLength: 1
       evalDebugLog:
         $ref: '#/definitions/evalDebugLog'
   evalDebugLog:

--- a/pkg/handler/data_record_frame_test.go
+++ b/pkg/handler/data_record_frame_test.go
@@ -3,7 +3,6 @@ package handler
 import (
 	"testing"
 
-	"github.com/checkr/flagr/pkg/util"
 	"github.com/checkr/flagr/swagger_gen/models"
 	"github.com/stretchr/testify/assert"
 )
@@ -13,11 +12,11 @@ func TestFrameOutput(t *testing.T) {
 		EvalContext: &models.EvalContext{
 			EntityID: "123",
 		},
-		FlagID:         util.Int64Ptr(int64(1)),
+		FlagID:         1,
 		FlagSnapshotID: 1,
-		SegmentID:      util.Int64Ptr(int64(1)),
-		VariantID:      util.Int64Ptr(int64(1)),
-		VariantKey:     util.StringPtr("control"),
+		SegmentID:      1,
+		VariantID:      1,
+		VariantKey:     "control",
 	}
 
 	t.Run("empty options", func(t *testing.T) {
@@ -75,11 +74,11 @@ func TestGetPartitionKey(t *testing.T) {
 			EvalContext: &models.EvalContext{
 				EntityID: "123",
 			},
-			FlagID:         util.Int64Ptr(int64(1)),
+			FlagID:         1,
 			FlagSnapshotID: 1,
-			SegmentID:      util.Int64Ptr(int64(1)),
-			VariantID:      util.Int64Ptr(int64(1)),
-			VariantKey:     util.StringPtr("control"),
+			SegmentID:      1,
+			VariantID:      1,
+			VariantKey:     "control",
 		}
 		frame := DataRecordFrame{evalResult: er}
 		assert.Equal(t, "123", frame.GetPartitionKey())

--- a/pkg/handler/data_recorder_kinesis.go
+++ b/pkg/handler/data_recorder_kinesis.go
@@ -1,7 +1,7 @@
 package handler
 
 import (
-	"github.com/a8m/kinesis-producer"
+	producer "github.com/a8m/kinesis-producer"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/kinesis"

--- a/pkg/handler/data_recorder_kinesis_test.go
+++ b/pkg/handler/data_recorder_kinesis_test.go
@@ -3,8 +3,7 @@ package handler
 import (
 	"testing"
 
-	"github.com/a8m/kinesis-producer"
-	"github.com/checkr/flagr/pkg/util"
+	producer "github.com/a8m/kinesis-producer"
 	"github.com/checkr/flagr/swagger_gen/models"
 	"github.com/stretchr/testify/assert"
 )
@@ -37,11 +36,11 @@ func TestKinesisAsyncRecord(t *testing.T) {
 					EvalContext: &models.EvalContext{
 						EntityID: "d08042018",
 					},
-					FlagID:         util.Int64Ptr(int64(1)),
+					FlagID:         1,
 					FlagSnapshotID: 1,
-					SegmentID:      util.Int64Ptr(int64(1)),
-					VariantID:      util.Int64Ptr(int64(1)),
-					VariantKey:     util.StringPtr("control"),
+					SegmentID:      1,
+					VariantID:      1,
+					VariantKey:     "control",
 				},
 			)
 		})

--- a/pkg/handler/data_recorder_pubsub_test.go
+++ b/pkg/handler/data_recorder_pubsub_test.go
@@ -6,7 +6,6 @@ import (
 
 	"cloud.google.com/go/pubsub"
 	"cloud.google.com/go/pubsub/pstest"
-	"github.com/checkr/flagr/pkg/util"
 	"github.com/checkr/flagr/swagger_gen/models"
 	"github.com/prashantv/gostub"
 	"github.com/stretchr/testify/assert"
@@ -45,11 +44,11 @@ func TestPubsubAsyncRecord(t *testing.T) {
 					EvalContext: &models.EvalContext{
 						EntityID: "d08042018",
 					},
-					FlagID:         util.Int64Ptr(int64(1)),
+					FlagID:         1,
 					FlagSnapshotID: 1,
-					SegmentID:      util.Int64Ptr(int64(1)),
-					VariantID:      util.Int64Ptr(int64(1)),
-					VariantKey:     util.StringPtr("control"),
+					SegmentID:      1,
+					VariantID:      1,
+					VariantKey:     "control",
 				},
 			)
 		})

--- a/pkg/handler/eval.go
+++ b/pkg/handler/eval.go
@@ -98,12 +98,10 @@ func BlankResult(f *entity.Flag, evalContext models.EvalContext, msg string) *mo
 			Msg:              msg,
 			SegmentDebugLogs: nil,
 		},
-		FlagID:         util.Int64Ptr(int64(flagID)),
-		FlagKey:        util.StringPtr(flagKey),
+		FlagID:         int64(flagID),
+		FlagKey:        flagKey,
 		FlagSnapshotID: int64(flagSnapshotID),
-		SegmentID:      nil,
-		VariantID:      nil,
-		Timestamp:      util.StringPtr(util.TimeNow()),
+		Timestamp:      util.TimeNow(),
 	}
 }
 
@@ -138,17 +136,17 @@ var evalFlag = func(evalContext models.EvalContext) *models.EvalResult {
 	}
 
 	logs := []*models.SegmentDebugLog{}
-	var vID *int64
-	var sID *int64
+	var vID int64
+	var sID int64
 
 	for _, segment := range f.Segments {
-		sID = util.Int64Ptr(int64(segment.ID))
+		sID = int64(segment.ID)
 		variantID, log, evalNextSegment := evalSegment(f.ID, evalContext, segment)
 		if config.Config.EvalDebugEnabled && evalContext.EnableDebug {
 			logs = append(logs, log)
 		}
 		if variantID != nil {
-			vID = util.Int64Ptr(int64(*variantID))
+			vID = int64(*variantID)
 		}
 		if !evalNextSegment {
 			break
@@ -161,7 +159,7 @@ var evalFlag = func(evalContext models.EvalContext) *models.EvalResult {
 	v := f.FlagEvaluation.VariantsMap[util.SafeUint(vID)]
 	if v != nil {
 		evalResult.VariantAttachment = v.Attachment
-		evalResult.VariantKey = util.StringPtr(v.Key)
+		evalResult.VariantKey = v.Key
 	}
 
 	logEvalResult(evalResult, f.DataRecordsEnabled)

--- a/pkg/handler/eval_test.go
+++ b/pkg/handler/eval_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/checkr/flagr/pkg/entity"
-	"github.com/checkr/flagr/pkg/util"
 	"github.com/checkr/flagr/swagger_gen/models"
 	"github.com/checkr/flagr/swagger_gen/restapi/operations/evaluation"
 	"github.com/jinzhu/gorm"
@@ -94,7 +93,7 @@ func TestEvalFlag(t *testing.T) {
 	t.Run("test empty evalContext", func(t *testing.T) {
 		defer gostub.StubFunc(&GetEvalCache, GenFixtureEvalCache()).Reset()
 		result := evalFlag(models.EvalContext{FlagID: int64(100)})
-		assert.Nil(t, result.VariantID)
+		assert.Zero(t, result.VariantID)
 		assert.NotZero(t, result.FlagID)
 		assert.NotEmpty(t, result.EvalContext.EntityID)
 	})
@@ -194,7 +193,7 @@ func TestEvalFlag(t *testing.T) {
 			FlagID:        int64(100),
 		})
 		assert.NotNil(t, result)
-		assert.Nil(t, result.VariantID)
+		assert.Zero(t, result.VariantID)
 	})
 
 	t.Run("test no match path with multiple constraints", func(t *testing.T) {
@@ -226,7 +225,7 @@ func TestEvalFlag(t *testing.T) {
 			FlagID:        int64(100),
 		})
 		assert.NotNil(t, result)
-		assert.Nil(t, result.VariantID)
+		assert.Zero(t, result.VariantID)
 	})
 
 	t.Run("test enabled=false", func(t *testing.T) {
@@ -242,7 +241,7 @@ func TestEvalFlag(t *testing.T) {
 			FlagID:        int64(100),
 		})
 		assert.NotNil(t, result)
-		assert.Nil(t, result.VariantID)
+		assert.Zero(t, result.VariantID)
 	})
 
 	t.Run("test entityType override", func(t *testing.T) {
@@ -329,7 +328,7 @@ func TestPostEvaluationBatch(t *testing.T) {
 }
 
 func TestRateLimitPerFlagConsoleLogging(t *testing.T) {
-	r := &models.EvalResult{FlagID: util.Int64Ptr(int64(1))}
+	r := &models.EvalResult{FlagID: 1}
 	t.Run("running fast triggers rate limiting", func(t *testing.T) {
 		for i := 0; i < 100; i++ {
 			rateLimitPerFlagConsoleLogging(r)

--- a/swagger/index.yaml
+++ b/swagger/index.yaml
@@ -408,20 +408,10 @@ definitions:
         type: string
   evalResult:
     type: object
-    required:
-      - flagID
-      - flagKey
-      - segmentID
-      - variantID
-      - variantKey
-      - variantAttachment
-      - evalContext
-      - timestamp
     properties:
       flagID:
         type: integer
         format: int64
-        minimum: 1
       flagKey:
         type: string
       flagSnapshotID:
@@ -430,21 +420,17 @@ definitions:
       segmentID:
         type: integer
         format: int64
-        minimum: 1
       variantID:
         type: integer
         format: int64
-        minimum: 1
       variantKey:
         type: string
-        minLength: 1
       variantAttachment:
         type: object
       evalContext:
         $ref: "#/definitions/evalContext"
       timestamp:
         type: string
-        minLength: 1
       evalDebugLog:
         $ref: "#/definitions/evalDebugLog"
   evalDebugLog:

--- a/swagger_gen/models/eval_result.go
+++ b/swagger_gen/models/eval_result.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/swag"
-	"github.com/go-openapi/validate"
 )
 
 // EvalResult eval result
@@ -18,47 +17,34 @@ import (
 type EvalResult struct {
 
 	// eval context
-	// Required: true
-	EvalContext *EvalContext `json:"evalContext"`
+	EvalContext *EvalContext `json:"evalContext,omitempty"`
 
 	// eval debug log
 	EvalDebugLog *EvalDebugLog `json:"evalDebugLog,omitempty"`
 
 	// flag ID
-	// Required: true
-	// Minimum: 1
-	FlagID *int64 `json:"flagID"`
+	FlagID int64 `json:"flagID,omitempty"`
 
 	// flag key
-	// Required: true
-	FlagKey *string `json:"flagKey"`
+	FlagKey string `json:"flagKey,omitempty"`
 
 	// flag snapshot ID
 	FlagSnapshotID int64 `json:"flagSnapshotID,omitempty"`
 
 	// segment ID
-	// Required: true
-	// Minimum: 1
-	SegmentID *int64 `json:"segmentID"`
+	SegmentID int64 `json:"segmentID,omitempty"`
 
 	// timestamp
-	// Required: true
-	// Min Length: 1
-	Timestamp *string `json:"timestamp"`
+	Timestamp string `json:"timestamp,omitempty"`
 
 	// variant attachment
-	// Required: true
-	VariantAttachment interface{} `json:"variantAttachment"`
+	VariantAttachment interface{} `json:"variantAttachment,omitempty"`
 
 	// variant ID
-	// Required: true
-	// Minimum: 1
-	VariantID *int64 `json:"variantID"`
+	VariantID int64 `json:"variantID,omitempty"`
 
 	// variant key
-	// Required: true
-	// Min Length: 1
-	VariantKey *string `json:"variantKey"`
+	VariantKey string `json:"variantKey,omitempty"`
 }
 
 // Validate validates this eval result
@@ -73,34 +59,6 @@ func (m *EvalResult) Validate(formats strfmt.Registry) error {
 		res = append(res, err)
 	}
 
-	if err := m.validateFlagID(formats); err != nil {
-		res = append(res, err)
-	}
-
-	if err := m.validateFlagKey(formats); err != nil {
-		res = append(res, err)
-	}
-
-	if err := m.validateSegmentID(formats); err != nil {
-		res = append(res, err)
-	}
-
-	if err := m.validateTimestamp(formats); err != nil {
-		res = append(res, err)
-	}
-
-	if err := m.validateVariantAttachment(formats); err != nil {
-		res = append(res, err)
-	}
-
-	if err := m.validateVariantID(formats); err != nil {
-		res = append(res, err)
-	}
-
-	if err := m.validateVariantKey(formats); err != nil {
-		res = append(res, err)
-	}
-
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
@@ -109,8 +67,8 @@ func (m *EvalResult) Validate(formats strfmt.Registry) error {
 
 func (m *EvalResult) validateEvalContext(formats strfmt.Registry) error {
 
-	if err := validate.Required("evalContext", "body", m.EvalContext); err != nil {
-		return err
+	if swag.IsZero(m.EvalContext) { // not required
+		return nil
 	}
 
 	if m.EvalContext != nil {
@@ -138,89 +96,6 @@ func (m *EvalResult) validateEvalDebugLog(formats strfmt.Registry) error {
 			}
 			return err
 		}
-	}
-
-	return nil
-}
-
-func (m *EvalResult) validateFlagID(formats strfmt.Registry) error {
-
-	if err := validate.Required("flagID", "body", m.FlagID); err != nil {
-		return err
-	}
-
-	if err := validate.MinimumInt("flagID", "body", int64(*m.FlagID), 1, false); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (m *EvalResult) validateFlagKey(formats strfmt.Registry) error {
-
-	if err := validate.Required("flagKey", "body", m.FlagKey); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (m *EvalResult) validateSegmentID(formats strfmt.Registry) error {
-
-	if err := validate.Required("segmentID", "body", m.SegmentID); err != nil {
-		return err
-	}
-
-	if err := validate.MinimumInt("segmentID", "body", int64(*m.SegmentID), 1, false); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (m *EvalResult) validateTimestamp(formats strfmt.Registry) error {
-
-	if err := validate.Required("timestamp", "body", m.Timestamp); err != nil {
-		return err
-	}
-
-	if err := validate.MinLength("timestamp", "body", string(*m.Timestamp), 1); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (m *EvalResult) validateVariantAttachment(formats strfmt.Registry) error {
-
-	if err := validate.Required("variantAttachment", "body", m.VariantAttachment); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (m *EvalResult) validateVariantID(formats strfmt.Registry) error {
-
-	if err := validate.Required("variantID", "body", m.VariantID); err != nil {
-		return err
-	}
-
-	if err := validate.MinimumInt("variantID", "body", int64(*m.VariantID), 1, false); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (m *EvalResult) validateVariantKey(formats strfmt.Registry) error {
-
-	if err := validate.Required("variantKey", "body", m.VariantKey); err != nil {
-		return err
-	}
-
-	if err := validate.MinLength("variantKey", "body", string(*m.VariantKey), 1); err != nil {
-		return err
 	}
 
 	return nil

--- a/swagger_gen/restapi/embedded_spec.go
+++ b/swagger_gen/restapi/embedded_spec.go
@@ -1322,16 +1322,6 @@ func init() {
     },
     "evalResult": {
       "type": "object",
-      "required": [
-        "flagID",
-        "flagKey",
-        "segmentID",
-        "variantID",
-        "variantKey",
-        "variantAttachment",
-        "evalContext",
-        "timestamp"
-      ],
       "properties": {
         "evalContext": {
           "$ref": "#/definitions/evalContext"
@@ -1341,8 +1331,7 @@ func init() {
         },
         "flagID": {
           "type": "integer",
-          "format": "int64",
-          "minimum": 1
+          "format": "int64"
         },
         "flagKey": {
           "type": "string"
@@ -1353,24 +1342,20 @@ func init() {
         },
         "segmentID": {
           "type": "integer",
-          "format": "int64",
-          "minimum": 1
+          "format": "int64"
         },
         "timestamp": {
-          "type": "string",
-          "minLength": 1
+          "type": "string"
         },
         "variantAttachment": {
           "type": "object"
         },
         "variantID": {
           "type": "integer",
-          "format": "int64",
-          "minimum": 1
+          "format": "int64"
         },
         "variantKey": {
-          "type": "string",
-          "minLength": 1
+          "type": "string"
         }
       }
     },
@@ -3070,16 +3055,6 @@ func init() {
     },
     "evalResult": {
       "type": "object",
-      "required": [
-        "flagID",
-        "flagKey",
-        "segmentID",
-        "variantID",
-        "variantKey",
-        "variantAttachment",
-        "evalContext",
-        "timestamp"
-      ],
       "properties": {
         "evalContext": {
           "$ref": "#/definitions/evalContext"
@@ -3089,8 +3064,7 @@ func init() {
         },
         "flagID": {
           "type": "integer",
-          "format": "int64",
-          "minimum": 1
+          "format": "int64"
         },
         "flagKey": {
           "type": "string"
@@ -3101,24 +3075,20 @@ func init() {
         },
         "segmentID": {
           "type": "integer",
-          "format": "int64",
-          "minimum": 1
+          "format": "int64"
         },
         "timestamp": {
-          "type": "string",
-          "minLength": 1
+          "type": "string"
         },
         "variantAttachment": {
           "type": "object"
         },
         "variantID": {
           "type": "integer",
-          "format": "int64",
-          "minimum": 1
+          "format": "int64"
         },
         "variantKey": {
-          "type": "string",
-          "minLength": 1
+          "type": "string"
         }
       }
     },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This caused an issue under the following circumstance:
* A flag did not exist in flagr
* The consumer requested a flag by only specifying `:flag_key`
* Flagr returned a 200 response with `:flag_id` omitted
* The ruby code generated by swagger raised an `ArgumentError` because the response from the server was missing `:flag_id`

Ultimately, it's up to the consumer app anyway to decide what it requires from the server response, not the HTTP interface library.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Unit test and integration tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.