### PR TITLE
Remove entity_type statsd tag

### DIFF
--- a/pkg/handler/eval.go
+++ b/pkg/handler/eval.go
@@ -195,7 +195,6 @@ var logEvalResultToDatadog = func(r *models.EvalResult) {
 	config.Global.StatsdClient.Incr(
 		"evaluation",
 		[]string{
-			fmt.Sprintf("EntityType:%s", util.SafeStringWithDefault(r.EvalContext.EntityType, "null")),
 			fmt.Sprintf("FlagID:%d", util.SafeUint(r.FlagID)),
 			fmt.Sprintf("VariantID:%d", util.SafeUint(r.VariantID)),
 			fmt.Sprintf("VariantKey:%s", util.SafeStringWithDefault(r.VariantKey, "null")),


### PR DESCRIPTION
`r.EvalContext.EntityType` has really high cardinality, removing it to save the datadog's 1k per metric limit.