### PR TITLE
add note support to flags

### DIFF
--- a/browser/flagr-ui/package.json
+++ b/browser/flagr-ui/package.json
@@ -17,6 +17,7 @@
     "diff": "^3.4.0",
     "element-ui": "^2.4.6",
     "lodash.clone": "^4.5.0",
+    "mavon-editor": "^2.7.0",
     "vue": "^2.5.0",
     "vue-json-editor": "^1.2.0",
     "vue-router": "^2.7.0",

--- a/browser/flagr-ui/src/components/Flag.vue
+++ b/browser/flagr-ui/src/components/Flag.vue
@@ -110,7 +110,7 @@
                     </div>
                   </div>
                 </div>
-                <el-card shadow="hover">
+                <el-card shadow="hover" :class="toggleInnerConfigCard">
                   <div class="flex-row id-row">
                     <div class="flex-row-left">
                       <el-tag type="primary" :disable-transitions="true">
@@ -607,6 +607,13 @@ export default {
         'el-icon-edit': !this.showMdEditor,
         'el-icon-view': this.showMdEditor
       }
+    },
+    toggleInnerConfigCard () {
+      if (!this.showMdEditor && !this.flag.notes) {
+        return 'flag-inner-config-card'
+      } else {
+        return ''
+      }
     }
   },
   methods: {
@@ -847,6 +854,12 @@ h5 {
     cursor: grab;
     cursor: -moz-grab;
     cursor: -webkit-grab;
+}
+
+.flag-inner-config-card {
+  .el-card__body {
+    padding-bottom: 0px;
+  }
 }
 
 .segment {

--- a/browser/flagr-ui/src/components/Flag.vue
+++ b/browser/flagr-ui/src/components/Flag.vue
@@ -198,6 +198,23 @@
                     </el-col>
                   </el-row>
                 </el-card>
+                <el-card>
+                  <div slot="header" class="el-card-header">
+                    <div class="flex-row">
+                      <div class="flex-row-left">
+                        <h2>Flag Notes</h2>
+                      </div>
+                      <div class="flex-row-right">
+                        <el-button circle style="float: right;" @click="toggleShowMdEditor" :class="editViewIcon"/>
+                      </div>
+                    </div>
+                  </div>
+                  <markdown-editor
+                    :showEditor="this.showMdEditor"
+                    :markdown.sync="flag.notes"
+                    @save="putFlag(flag)"
+                  ></markdown-editor>
+                </el-card>
               </el-card>
 
               <el-card class="variants-container">
@@ -489,6 +506,7 @@ import helpers from '@/helpers/helpers'
 import Spinner from '@/components/Spinner'
 import DebugConsole from '@/components/DebugConsole'
 import FlagHistory from '@/components/FlagHistory'
+import MarkdownEditor from '@/components/MarkdownEditor.vue'
 import {operators} from '@/../config/operators.json'
 
 const OPERATOR_VALUE_TO_LABEL_MAP = operators.reduce((acc, el) => {
@@ -542,7 +560,8 @@ export default {
     spinner: Spinner,
     debugConsole: DebugConsole,
     flagHistory: FlagHistory,
-    draggable: draggable
+    draggable: draggable,
+    MarkdownEditor
   },
   data () {
     return {
@@ -562,14 +581,16 @@ export default {
         key: '',
         segments: [],
         updatedAt: '',
-        variants: []
+        variants: [],
+        notes: ''
       },
       newSegment: clone(DEFAULT_SEGMENT),
       newVariant: clone(DEFAULT_VARIANT),
       selectedSegment: null,
       newDistributions: {},
       operatorOptions: operators,
-      operatorValueToLabelMap: OPERATOR_VALUE_TO_LABEL_MAP
+      operatorValueToLabelMap: OPERATOR_VALUE_TO_LABEL_MAP,
+      showMdEditor: false
     }
   },
   computed: {
@@ -582,6 +603,12 @@ export default {
     },
     flagId () {
       return this.$route.params.flagId
+    },
+    editViewIcon () {
+      return {
+        'el-icon-edit': !this.showMdEditor,
+        'el-icon-view': this.showMdEditor
+      }
     }
   },
   methods: {
@@ -598,9 +625,10 @@ export default {
         description: flag.description,
         dataRecordsEnabled: flag.dataRecordsEnabled,
         key: flag.key || '',
-        entityType: flag.entityType || ''
+        entityType: flag.entityType || '',
+        notes: flag.notes || ''
       }).then(() => {
-        this.$message.success(`You've updated flag`)
+        this.$message.success(`Flag updated`)
       }, handleErr.bind(this))
     },
     setFlagEnabled (checked) {
@@ -799,6 +827,9 @@ export default {
       Axios.get(`${API_URL}/flags/entity_types`).then(response => {
         this.entityTypes = prepareEntityTypes(response.data)
       }, handleErr.bind(this))
+    },
+    toggleShowMdEditor () {
+      this.showMdEditor = !this.showMdEditor
     }
   },
   mounted () {

--- a/browser/flagr-ui/src/components/Flag.vue
+++ b/browser/flagr-ui/src/components/Flag.vue
@@ -197,23 +197,21 @@
                       </div>
                     </el-col>
                   </el-row>
-                </el-card>
-                <el-card>
-                  <div slot="header" class="el-card-header">
-                    <div class="flex-row">
-                      <div class="flex-row-left">
-                        <h2>Flag Notes</h2>
-                      </div>
-                      <div class="flex-row-right">
-                        <el-button circle style="float: right;" @click="toggleShowMdEditor" :class="editViewIcon"/>
-                      </div>
-                    </div>
-                  </div>
-                  <markdown-editor
-                    :showEditor="this.showMdEditor"
-                    :markdown.sync="flag.notes"
-                    @save="putFlag(flag)"
-                  ></markdown-editor>
+                  <el-row style="margin: 10px">
+                    <h5>
+                      <span>Flag Notes</span>
+                      <el-button round size="mini" @click="toggleShowMdEditor">
+                        <span :class="editViewIcon"></span> {{ !this.showMdEditor ? 'edit' : 'view' }}
+                      </el-button>
+                    </h5>
+                  </el-row>
+                  <el-row>
+                    <markdown-editor
+                      :showEditor="this.showMdEditor"
+                      :markdown.sync="flag.notes"
+                      @save="putFlag(flag)"
+                    ></markdown-editor>
+                  </el-row>
                 </el-card>
               </el-card>
 

--- a/browser/flagr-ui/src/components/MarkdownEditor.vue
+++ b/browser/flagr-ui/src/components/MarkdownEditor.vue
@@ -1,7 +1,6 @@
 <template>
-    <div id="editor">
+    <div id="editor" v-if="hideMdBox">
         <mavon-editor
-          v-if="hideMdBox"
           language="en"
           v-bind="editorSettings"
           :value="markdown"

--- a/browser/flagr-ui/src/components/MarkdownEditor.vue
+++ b/browser/flagr-ui/src/components/MarkdownEditor.vue
@@ -1,0 +1,66 @@
+<template>
+    <div id="editor">
+        <mavon-editor
+          v-if="hideMdBox"
+          language="en"
+          v-bind="editorSettings"
+          :value="markdown"
+          @save="save"
+          @change="syncMarkdown"
+        ></mavon-editor>
+    </div>
+</template>
+
+<script>
+
+import { mavonEditor } from 'mavon-editor'
+import 'mavon-editor/dist/css/index.css'
+
+export default {
+  name: 'editor',
+  props: {
+    showEditor: Boolean,
+    markdown: {
+      type: String,
+      default: ''
+    }
+  },
+  components: {
+    mavonEditor
+  },
+  data () {
+    return {
+      editorSettings: {
+        toolbarsFlag: false,
+        subfield: false,
+        defaultOpen: 'preview'
+      }
+    }
+  },
+  computed: {
+    hideMdBox: function () {
+      return this.markdown.length > 0 || this.showEditor
+    }
+  },
+  methods: {
+    toggleEditor (show) {
+      this.editorSettings.toolbarsFlag = show
+      this.editorSettings.subfield = show
+    },
+    syncMarkdown (md, _) {
+      this.$emit('update:markdown', md)
+    },
+    save () {
+      this.$emit('save')
+    }
+  },
+  watch: {
+    showEditor: function () {
+      this.toggleEditor(this.showEditor)
+    }
+  },
+  mounted () {
+    this.toggleEditor(this.showEditor)
+  }
+}
+</script>

--- a/browser/flagr-ui/yarn.lock
+++ b/browser/flagr-ui/yarn.lock
@@ -3226,6 +3226,16 @@ he@^1.1.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
 
+highlight.js-async-webpack@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/highlight.js-async-webpack/-/highlight.js-async-webpack-1.0.4.tgz#c06b67bf99f049045d62b756e5855b0912ec616c"
+  integrity sha1-wGtnv5nwSQRdYrdW5YVbCRLsYWw=
+
+highlight.js@^9.11.0:
+  version "9.15.6"
+  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-9.15.6.tgz#72d4d8d779ec066af9a17cb14360c3def0aa57c4"
+  integrity sha512-zozTAWM1D6sozHo8kqhfYgsac+B+q0PmsjXeyDrYIHHcBN0zTVT66+s2GW1GZv7DbyaROdLXKdabwS/WqPyIdQ==
+
 hmac-drbg@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/hmac-drbg/-/hmac-drbg-1.0.1.tgz#d2745701025a6c775a6c545793ed502fc0c649a1"
@@ -4238,6 +4248,14 @@ math-expression-evaluator@^1.2.14:
 math-random@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/math-random/-/math-random-1.0.1.tgz#8b3aac588b8a66e4975e3cdea67f7bb329601fac"
+
+mavon-editor@^2.7.0:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/mavon-editor/-/mavon-editor-2.7.0.tgz#fa1978b1ff2a738516774117c83323c0347ef713"
+  integrity sha512-NonoBxMdFDGMZTZIRDDEbqZ/PLbGW1FNbaWIT10dZ3mvMUJVorniReVPng3nWBa1eb6xj5LUP2z/GCpSOytm8Q==
+  dependencies:
+    highlight.js "^9.11.0"
+    highlight.js-async-webpack "^1.0.4"
 
 md5.js@^1.3.4:
   version "1.3.5"

--- a/docs/api_docs/bundle.yaml
+++ b/docs/api_docs/bundle.yaml
@@ -823,6 +823,9 @@ definitions:
           it will override the entityType in the evaluation logs if it's not
           empty
         type: string
+      notes:
+        description: flag usage details in markdown format
+        type: string
       createdBy:
         type: string
       updatedBy:
@@ -862,6 +865,9 @@ definitions:
         type: boolean
         x-nullable: true
       key:
+        type: string
+        x-nullable: true
+      notes:
         type: string
         x-nullable: true
   setFlagEnabledRequest:

--- a/pkg/entity/flag.go
+++ b/pkg/entity/flag.go
@@ -18,7 +18,8 @@ type Flag struct {
 	Enabled     bool
 	Segments    []Segment
 	Variants    []Variant
-	SnapshotID  uint `json:"-"`
+	SnapshotID  uint   `json:"-"`
+	Notes       string `sql:"type:text"`
 
 	DataRecordsEnabled bool
 	EntityType         string

--- a/pkg/handler/crud.go
+++ b/pkg/handler/crud.go
@@ -229,6 +229,10 @@ func (c *crud) PutFlag(params flag.PutFlagParams) middleware.Responder {
 		f.EntityType = et
 	}
 
+	if params.Body.Notes != nil {
+		f.Notes = *params.Body.Notes
+	}
+
 	if err := tx.Save(f).Error; err != nil {
 		return flag.NewPutFlagDefault(500).WithPayload(ErrorMessage("%s", err))
 	}

--- a/pkg/handler/crud_test.go
+++ b/pkg/handler/crud_test.go
@@ -79,6 +79,7 @@ func TestCrudFlags(t *testing.T) {
 				Description:        util.StringPtr("another funny flag"),
 				DataRecordsEnabled: util.BoolPtr(true),
 				Key:                util.StringPtr("flag_key_1"),
+				Notes:              util.StringPtr("# funny flag notes"),
 			}},
 		)
 		assert.NotZero(t, res.(*flag.PutFlagOK).Payload.ID)

--- a/pkg/mapper/entity_restapi/e2r/e2r.go
+++ b/pkg/mapper/entity_restapi/e2r/e2r.go
@@ -20,6 +20,7 @@ func MapFlag(e *entity.Flag) (*models.Flag, error) {
 	r.DataRecordsEnabled = util.BoolPtr(e.DataRecordsEnabled)
 	r.EntityType = e.EntityType
 	r.Description = util.StringPtr(e.Description)
+	r.Notes = e.Notes
 	r.Enabled = util.BoolPtr(e.Enabled)
 	r.UpdatedAt = strfmt.DateTime(e.UpdatedAt)
 	r.UpdatedBy = e.UpdatedBy

--- a/swagger/index.yaml
+++ b/swagger/index.yaml
@@ -120,6 +120,9 @@ definitions:
       entityType:
         description: it will override the entityType in the evaluation logs if it's not empty
         type: string
+      notes:
+        description: flag usage details in markdown format
+        type: string
       createdBy:
         type: string
       updatedBy:
@@ -157,6 +160,9 @@ definitions:
         type: boolean
         x-nullable: true
       key:
+        type: string
+        x-nullable: true
+      notes:
         type: string
         x-nullable: true
   setFlagEnabledRequest:

--- a/swagger_gen/models/flag.go
+++ b/swagger_gen/models/flag.go
@@ -47,6 +47,9 @@ type Flag struct {
 	// Min Length: 1
 	Key string `json:"key,omitempty"`
 
+	// flag usage details in markdown format
+	Notes string `json:"notes,omitempty"`
+
 	// segments
 	Segments []*Segment `json:"segments"`
 

--- a/swagger_gen/models/put_flag_request.go
+++ b/swagger_gen/models/put_flag_request.go
@@ -32,6 +32,9 @@ type PutFlagRequest struct {
 
 	// key
 	Key *string `json:"key,omitempty"`
+
+	// notes
+	Notes *string `json:"notes,omitempty"`
 }
 
 // Validate validates this put flag request

--- a/swagger_gen/restapi/embedded_spec.go
+++ b/swagger_gen/restapi/embedded_spec.go
@@ -1461,6 +1461,10 @@ func init() {
           "type": "string",
           "minLength": 1
         },
+        "notes": {
+          "description": "flag usage details in markdown format",
+          "type": "string"
+        },
         "segments": {
           "type": "array",
           "items": {
@@ -1544,6 +1548,10 @@ func init() {
           "x-nullable": true
         },
         "key": {
+          "type": "string",
+          "x-nullable": true
+        },
+        "notes": {
           "type": "string",
           "x-nullable": true
         }
@@ -3194,6 +3202,10 @@ func init() {
           "type": "string",
           "minLength": 1
         },
+        "notes": {
+          "description": "flag usage details in markdown format",
+          "type": "string"
+        },
         "segments": {
           "type": "array",
           "items": {
@@ -3277,6 +3289,10 @@ func init() {
           "x-nullable": true
         },
         "key": {
+          "type": "string",
+          "x-nullable": true
+        },
+        "notes": {
           "type": "string",
           "x-nullable": true
         }


### PR DESCRIPTION
## Description
Related to issue #230

Adds a new notes section to the flag config view and updates the API to allow for adding a flag with attached notes in markdown format. Notes can be used for adding details about flag usage, describing the flag's purpose, adding examples of usage, etc.

Collapsed view when no notes are present:
<img width="1625" alt="Screen Shot 2019-03-23 at 8 30 13 PM" src="https://user-images.githubusercontent.com/5851331/54873351-dc75d680-4daa-11e9-8070-ba856cad910a.png">

Editor view:
<img width="1621" alt="Screen Shot 2019-03-23 at 8 32 16 PM" src="https://user-images.githubusercontent.com/5851331/54873358-f31c2d80-4daa-11e9-94ec-186b52a067f6.png">

View when notes present:
<img width="1610" alt="Screen Shot 2019-03-23 at 8 32 40 PM" src="https://user-images.githubusercontent.com/5851331/54873361-04653a00-4dab-11e9-9280-337eb2e2c73f.png">

## Motivation and Context
This solves the inconvenience of having to have separate, hard-to-find documentation pages for a given flag. Instead, all relevant documentation is held on the flag config page itself.

## How Has This Been Tested?
Manual UI testing and updated CRUD tests to check for new field acceptance.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.