### PR TITLE
ensure header color css applies only within el-card__header

### DIFF
--- a/browser/flagr-ui/src/App.vue
+++ b/browser/flagr-ui/src/App.vue
@@ -146,12 +146,12 @@ ul {
   .el-card {
     .el-card__header {
       background-color: #74E5E0;
+      h2 {
+        margin: -0.2em;
+        color: white;
+      }
     }
     margin-bottom: 1em;
-    h2 {
-      margin: -0.2em;
-      color: white;
-    }
   }
 
   .jsoneditor{


### PR DESCRIPTION
this ensures that h2 text within cards does not become unreadable. resolves an issue where h2s within flag notes are displayed as white text on a white background