### PR TITLE
Allow more capital characters and numbers in flag keys and variant keys

### DIFF
--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -12,7 +12,7 @@ import (
 
 var (
 	keyLengthLimit = 63
-	keyRegex       = regexp.MustCompile("^[a-z]+[a-z0-9_]*$")
+	keyRegex       = regexp.MustCompile("^[\\w\\d-]+$")
 
 	randomKeyCharset = []byte("123456789abcdefghijkmnopqrstuvwxyz")
 	randomKeyPrefix  = "k"

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -82,11 +82,15 @@ func TestIsSafeKey(t *testing.T) {
 	assert.Empty(t, msg)
 
 	b, msg = IsSafeKey("1a")
-	assert.False(t, b)
+	assert.True(t, b)
 	assert.NotEmpty(t, msg)
 
+	b, msg = IsSafeKey("  ")
+	assert.false(t, b)
+	assert.NotEmpty(t, msg)	
+
 	b, msg = IsSafeKey("_a")
-	assert.False(t, b)
+	assert.True(t, b)
 	assert.NotEmpty(t, msg)
 
 	b, msg = IsSafeKey(strings.Repeat("a", 64))


### PR DESCRIPTION
Allowing capital letters and numbers in flag keys and variant keys. This helps with use cases where keys are being migrated from legacy systems to flagr.

## Description
Change regex to accomodate to allow any word character, digits and hyphen.

## Motivation and Context
This resolves https://github.com/checkr/flagr/issues/254.

## How Has This Been Tested?
Wrote unit tests plus tested locally by creating keys with capital letters and digits.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My code follows the code style of this project.
- [x ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ x] I have added tests to cover my changes.
- [x ] All new and existing tests passed.