### PR TITLE
Allow more capital characters and numbers in flag keys and variant keys

### DIFF
--- a/pkg/entity/flag_test.go
+++ b/pkg/entity/flag_test.go
@@ -33,7 +33,7 @@ func TestCreateFlagKey(t *testing.T) {
 	})
 
 	t.Run("invalid key", func(t *testing.T) {
-		key, err := CreateFlagKey("1-2-3")
+		key, err := CreateFlagKey(" spaces in key are not allowed 1-2-3")
 		assert.Error(t, err)
 		assert.Zero(t, key)
 	})
@@ -52,7 +52,7 @@ func TestCreateFlagEntityType(t *testing.T) {
 		f := GenFixtureFlag()
 		db := PopulateTestDB(f)
 
-		err := CreateFlagEntityType(db, "123-invalid-key")
+		err := CreateFlagEntityType(db, " spaces in key are not allowed 123-invalid-key")
 		assert.Error(t, err)
 	})
 }

--- a/pkg/handler/crud_test.go
+++ b/pkg/handler/crud_test.go
@@ -191,8 +191,8 @@ func TestCrudFlagsWithFailures(t *testing.T) {
 	t.Run("CreateFlag - invalid key error", func(t *testing.T) {
 		res = c.CreateFlag(flag.CreateFlagParams{
 			Body: &models.CreateFlagRequest{
-				Description: util.StringPtr("funny flag"),
-				Key:         "1-2-3", // invalid key
+				Description: util.StringPtr(" flag with a space"),
+				Key:         " 1-2-3", // invalid key
 			},
 		})
 		assert.NotZero(t, res.(*flag.CreateFlagDefault).Payload)
@@ -811,7 +811,7 @@ func TestCrudVariantsWithFailures(t *testing.T) {
 		res = c.CreateVariant(variant.CreateVariantParams{
 			FlagID: int64(1),
 			Body: &models.CreateVariantRequest{
-				Key: util.StringPtr("123_invalid_key"),
+				Key: util.StringPtr(" 123_invalid_key"),
 			},
 		})
 		assert.NotZero(t, res.(*variant.CreateVariantDefault).Payload)
@@ -868,7 +868,7 @@ func TestCrudVariantsWithFailures(t *testing.T) {
 			FlagID:    int64(1),
 			VariantID: int64(1),
 			Body: &models.PutVariantRequest{
-				Key: util.StringPtr("123_invalid_key"),
+				Key: util.StringPtr(" spaces in key 123_invalid_key"),
 			},
 		})
 		assert.NotZero(t, *res.(*variant.PutVariantDefault).Payload)

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -12,7 +12,7 @@ import (
 
 var (
 	keyLengthLimit = 63
-	keyRegex       = regexp.MustCompile("^[\\w\\d-]+$")
+	keyRegex       = regexp.MustCompile(`^[\w\d-]+$`)
 
 	randomKeyCharset = []byte("123456789abcdefghijkmnopqrstuvwxyz")
 	randomKeyPrefix  = "k"

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -12,7 +12,7 @@ import (
 
 var (
 	keyLengthLimit = 63
-	keyRegex       = regexp.MustCompile("^[a-z]+[a-z0-9_]*$")
+	keyRegex       = regexp.MustCompile("^[\\w\\d-]+$")
 
 	randomKeyCharset = []byte("123456789abcdefghijkmnopqrstuvwxyz")
 	randomKeyPrefix  = "k"

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -82,11 +82,15 @@ func TestIsSafeKey(t *testing.T) {
 	assert.Empty(t, msg)
 
 	b, msg = IsSafeKey("1a")
-	assert.False(t, b)
+	assert.True(t, b)
 	assert.NotEmpty(t, msg)
 
-	b, msg = IsSafeKey("_a")
+	b, msg = IsSafeKey("  ")
 	assert.False(t, b)
+	assert.NotEmpty(t, msg)	
+
+	b, msg = IsSafeKey("_a")
+	assert.True(t, b)
 	assert.NotEmpty(t, msg)
 
 	b, msg = IsSafeKey(strings.Repeat("a", 64))

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -83,15 +83,15 @@ func TestIsSafeKey(t *testing.T) {
 
 	b, msg = IsSafeKey("1a")
 	assert.True(t, b)
-	assert.NotEmpty(t, msg)
+	assert.Empty(t, msg)
 
-	b, msg = IsSafeKey("  ")
+	b, msg = IsSafeKey(" spaces in key are not allowed ")
 	assert.False(t, b)
 	assert.NotEmpty(t, msg)	
 
 	b, msg = IsSafeKey("_a")
 	assert.True(t, b)
-	assert.NotEmpty(t, msg)
+	assert.Empty(t, msg)
 
 	b, msg = IsSafeKey(strings.Repeat("a", 64))
 	assert.False(t, b)


### PR DESCRIPTION
Allowing capital letters and numbers in flag keys and variant keys. This helps with use cases where keys are being migrated from legacy systems to flagr.

## Description
Change flag key regex to accommodate to allow any word character, digits and hyphen.

## Motivation and Context
This resolves issue 254. 
https://github.com/checkr/flagr/issues/254

## How Has This Been Tested?
Changed unit tests and tested locally by creating keys with capital letters and digits and other combinations.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.