### PR TITLE
Add support for arbitrary JSON in attachments

### DIFF
--- a/pkg/entity/fixture.go
+++ b/pkg/entity/fixture.go
@@ -25,7 +25,7 @@ func GenFixtureFlag() Flag {
 				Model:  gorm.Model{ID: 301},
 				FlagID: 100,
 				Key:    "treatment",
-				Attachment: map[string]string{
+				Attachment: map[string]interface{}{
 					"value": "321",
 				},
 			},

--- a/pkg/entity/variant.go
+++ b/pkg/entity/variant.go
@@ -28,7 +28,7 @@ func (v *Variant) Validate() error {
 }
 
 // Attachment supports dynamic configuration in variant
-type Attachment map[string]string
+type Attachment map[string]interface{}
 
 // Scan implements scanner interface
 func (a *Attachment) Scan(value interface{}) error {

--- a/pkg/handler/crud_test.go
+++ b/pkg/handler/crud_test.go
@@ -768,6 +768,33 @@ func TestCrudVariants(t *testing.T) {
 	})
 	assert.Equal(t, *res.(*variant.PutVariantOK).Payload.Key, "another_control")
 
+	res = c.PutVariant(variant.PutVariantParams{
+		FlagID:    int64(1),
+		VariantID: int64(1),
+		Body: &models.PutVariantRequest{
+			Key: util.StringPtr("another_control"),
+			Attachment: map[string]interface{}{
+				"valid_int_value": 1,
+			},
+		},
+	})
+	assert.Equal(t, *res.(*variant.PutVariantOK).Payload.Key, "another_control")
+
+	res = c.PutVariant(variant.PutVariantParams{
+		FlagID:    int64(1),
+		VariantID: int64(1),
+		Body: &models.PutVariantRequest{
+			Key: util.StringPtr("another_control"),
+			Attachment: map[string]interface{}{
+				"valid_structured_value": map[string]interface{}{
+					"string_value": "string",
+					"int_value":    1,
+				},
+			},
+		},
+	})
+	assert.Equal(t, *res.(*variant.PutVariantOK).Payload.Key, "another_control")
+
 	// step 4. it should be able to delete the variant
 	res = c.DeleteVariant(variant.DeleteVariantParams{
 		FlagID:    int64(1),
@@ -844,20 +871,6 @@ func TestCrudVariantsWithFailures(t *testing.T) {
 			VariantID: int64(999999),
 			Body: &models.PutVariantRequest{
 				Key: util.StringPtr("another_control"),
-			},
-		})
-		assert.NotZero(t, *res.(*variant.PutVariantDefault).Payload)
-	})
-
-	t.Run("PutVariant - put invalid attachment", func(t *testing.T) {
-		res = c.PutVariant(variant.PutVariantParams{
-			FlagID:    int64(1),
-			VariantID: int64(1),
-			Body: &models.PutVariantRequest{
-				Key: util.StringPtr("another_control"),
-				Attachment: map[string]interface{}{
-					"invalid_int_value": 1,
-				},
 			},
 		})
 		assert.NotZero(t, *res.(*variant.PutVariantDefault).Payload)

--- a/pkg/mapper/entity_restapi/r2e/r2e.go
+++ b/pkg/mapper/entity_restapi/r2e/r2e.go
@@ -36,15 +36,9 @@ func MapAttachment(a interface{}) (entity.Attachment, error) {
 	if a != nil {
 		m, ok := a.(map[string]interface{})
 		if !ok {
-			return e, fmt.Errorf("all key/value pairs should be string/string. invalid attachment format %s", spew.Sdump(a))
+			return e, fmt.Errorf("Make sure JSON is properly formatted into key/value pairs. Invalid attachment format %s", spew.Sdump(a))
 		}
-		for k, v := range m {
-			s, ok := v.(string)
-			if !ok {
-				return e, fmt.Errorf("all key/value pairs should be string/string. invalid attachment format %s", spew.Sdump(a))
-			}
-			e[k] = s
-		}
+		e = m
 	}
 	return e, nil
 }


### PR DESCRIPTION
Allow storing arbitrary JSON structures within variants' attachment field

## Description
Update the Attachment field type from map[string]string to map[string]interface{}

## Motivation and Context
Enable using flagr as a smart general configuration store and remove hacks that use strings in order to store structured data

## How Has This Been Tested?
The existing tests were updated to accommodate for this change

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.