### PR TITLE
Add search bar for filtering flags in home page

### DIFF
--- a/browser/flagr-ui/src/components/Flags.vue
+++ b/browser/flagr-ui/src/components/Flags.vue
@@ -136,8 +136,8 @@ export default {
       if (this.searchTerm) {
         this.filteredFlags = this.flags.filter(
           ({ id, description}) =>
-            id.toString().startsWith(this.searchTerm) ||
-            description.startsWith(this.searchTerm)
+            id.toString().includes(this.searchTerm) ||
+            description.includes(this.searchTerm)
         )
       }
       else {

--- a/browser/flagr-ui/src/components/Flags.vue
+++ b/browser/flagr-ui/src/components/Flags.vue
@@ -29,8 +29,16 @@
             </el-col>
           </el-row>
 
+          <el-row>
+            <el-input
+              placeholder="Search a flag"
+              prefix-icon="el-icon-search"
+              v-model="searchTerm">
+            </el-input>
+          </el-row>
+
           <el-table
-            :data="flags"
+            :data="filteredFlags"
             :stripe="true"
             :highlight-current-row="false"
             :default-sort="{prop: 'id', order: 'descending'}"
@@ -106,6 +114,8 @@ export default {
     return {
       loaded: false,
       flags: [],
+      filteredFlags: [],
+      searchTerm: '',
       newFlag: {
         description: ''
       }
@@ -118,7 +128,22 @@ export default {
         this.loaded = true
         flags.reverse()
         this.flags = flags
+        this.filteredFlags = [...flags];
       }, handleErr.bind(this))
+  },
+  watch: {
+    searchTerm: function() {
+      if (this.searchTerm) {
+        this.filteredFlags = this.flags.filter(
+          ({ id, description}) =>
+            id.toString().startsWith(this.searchTerm) ||
+            description.startsWith(this.searchTerm)
+        )
+      }
+      else {
+        this.filteredFlags = [...this.flags]
+      }
+    }
   },
   methods: {
     flagEnabledFormatter (row, col, val) {


### PR DESCRIPTION
## Description
I added a search bar that can help to find a flag throw a big number of flags on the home page.

## Motivation and Context
When the usage of flagr grows, I tend to add more flags for every configuration I have. By doing that, I affect directly the length of the list of flags on the home page. I was trying to suggest a new way to navigate throw all the flags easily.

## How Has This Been Tested?
Tested locally, manually.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.