### PR TITLE
Height fix for json-editor in variant attachment

### DIFF
--- a/browser/flagr-ui/src/components/Flag.vue
+++ b/browser/flagr-ui/src/components/Flag.vue
@@ -961,12 +961,6 @@ ol.constraints-inner {
   }
 }
 
-.variant-attachment-content {
-  .jsoneditor {
-    height: 130px;
-  }
-}
-
 .variant-attachment-collapsable-title {
   margin: 0;
   font-size: 13px;


### PR DESCRIPTION
## Description
As part of improving the existing UI, we replaced the existing variant attachment input with json-editor. In this PR there was a bug which set the height of that container and causes it to look bad when it should expand.

## Motivation and Context
This change is required in order to have a better look and feel. It solves the mentioned styling issue.

Before:
![image](https://user-images.githubusercontent.com/13322290/59301835-32b43080-8c9b-11e9-9257-7369f225b572.png)

After:
![image](https://user-images.githubusercontent.com/13322290/59302177-0816a780-8c9c-11e9-931a-8b50841fcf6d.png)


## How Has This Been Tested?
Manually, locally.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.