### PR TITLE
Use alpine 3.10 with glibc and bump remote docker in ciecleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker:
-          version: 18.06.0-ce
+          version: 18.09.3
           docker_layer_caching: true
       - run: cd integration_tests && make build-image
       - run: cd integration_tests && make down

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,8 @@ RUN make build
 ######################################
 # Copy from builder to alpine image
 ######################################
-FROM alpine:3.6
-RUN apk add --no-cache libc6-compat ca-certificates curl
+FROM frolvlad/alpine-glibc:alpine-3.10
+RUN apk add --no-cache curl
 WORKDIR /go/src/github.com/checkr/flagr
 VOLUME ["/data"]
 

--- a/integration_tests/Dockerfile-Integration-Test
+++ b/integration_tests/Dockerfile-Integration-Test
@@ -9,8 +9,8 @@ RUN make build
 ######################################
 # Copy from builder to alpine image
 ######################################
-FROM alpine:3.6
-RUN apk add --no-cache libc6-compat ca-certificates curl
+FROM frolvlad/alpine-glibc:alpine-3.10
+RUN apk add --no-cache curl
 WORKDIR /go/src/github.com/checkr/flagr
 COPY --from=go_builder /go/src/github.com/checkr/flagr/flagr ./flagr
 VOLUME ["/data"]


### PR DESCRIPTION
`libc6-compat` looks not working correctly in the circleci environment. `fnctl64 not found` was thrown in the new integration tests and alpine 3.6 images.

Wanna test if bumping the alpine to 3.10 with glibc and the remote docker engine can solve the error of https://circleci.com/gh/checkr/flagr/907

Specifically, https://hub.docker.com/r/frolvlad/alpine-glibc and https://github.com/frol/docker-alpine-glibc is a popular alpine glibc base image to get started. 