### PR TITLE
added support for validating HS512 JWT tokens

### DIFF
--- a/pkg/config/env.go
+++ b/pkg/config/env.go
@@ -162,7 +162,7 @@ var Config = struct {
 		If you wish to use JWT Auth via headers you can simply set the header `Authorization Bearer [access_token]`
 
 	Supported signing methods:
-		* HS256, in this case `FLAGR_JWT_AUTH_SECRET` contains the passphrase
+		* HS256/HS512, in this case `FLAGR_JWT_AUTH_SECRET` contains the passphrase
 		* RS256, in this case `FLAGR_JWT_AUTH_SECRET` contains the key in PEM Format
 
 	Note:

--- a/pkg/config/middleware.go
+++ b/pkg/config/middleware.go
@@ -127,6 +127,9 @@ func setupJWTAuthMiddleware() *auth {
 	case "HS256":
 		signingMethod = jwt.SigningMethodHS256
 		validationKey = []byte(Config.JWTAuthSecret)
+	case "HS512":
+		signingMethod = jwt.SigningMethodHS512
+		validationKey = []byte(Config.JWTAuthSecret)
 	case "RS256":
 		signingMethod = jwt.SigningMethodRS256
 		validationKey, errParsingKey = jwt.ParseRSAPublicKeyFromPEM([]byte(Config.JWTAuthSecret))

--- a/pkg/config/middleware_test.go
+++ b/pkg/config/middleware_test.go
@@ -27,6 +27,9 @@ const (
 
 	// Signed with secret: "mysecret"
 	validHS256JWTTokenWithSecret = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.drt_po6bHhDOF_FJEHTrK-KD8OGjseJZpHwHIgsnoTM"
+
+	// Signed with secret: "mysecret"
+	validHS512JWTTokenWithSecret = "eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.G4VTPaWRHtByF6SaHSQFTeu-896jFb2dF2KnYjJTa9MY_a6Tbb9BsO7Uu0Ju_QOGGDI_b-k6U0T6qwj9lA5_Aw"
 )
 
 func (o *okHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
@@ -224,6 +227,28 @@ o2kQ+X5xK9cipRgEKwIDAQAB
 		req.AddCookie(&http.Cookie{
 			Name:  "access_token",
 			Value: validHS256JWTToken,
+		})
+		hh.ServeHTTP(res, req)
+		assert.Equal(t, http.StatusOK, res.Code)
+	})
+
+	t.Run("it will pass if jwt enabled with correct header token encrypted using HS512", func(t *testing.T) {
+		Config.JWTAuthEnabled = true
+		Config.JWTAuthSecret = "mysecret"
+		Config.JWTAuthSigningMethod = "HS512"
+		Config.JWTAuthDebug = true
+		defer func() {
+			Config.JWTAuthEnabled = false
+			Config.JWTAuthSecret = ""
+		}()
+		hh := SetupGlobalMiddleware(h)
+
+		res := httptest.NewRecorder()
+		res.Body = new(bytes.Buffer)
+		req, _ := http.NewRequest("GET", "http://localhost:18000/api/v1/flags", nil)
+		req.AddCookie(&http.Cookie{
+			Name:  "access_token",
+			Value: validHS512JWTTokenWithSecret,
 		})
 		hh.ServeHTTP(res, req)
 		assert.Equal(t, http.StatusOK, res.Code)

--- a/pkg/config/middleware_test.go
+++ b/pkg/config/middleware_test.go
@@ -240,6 +240,7 @@ o2kQ+X5xK9cipRgEKwIDAQAB
 		defer func() {
 			Config.JWTAuthEnabled = false
 			Config.JWTAuthSecret = ""
+			Config.JWTAuthSigningMethod = ""
 		}()
 		hh := SetupGlobalMiddleware(h)
 

--- a/pkg/config/middleware_test.go
+++ b/pkg/config/middleware_test.go
@@ -236,7 +236,6 @@ o2kQ+X5xK9cipRgEKwIDAQAB
 		Config.JWTAuthEnabled = true
 		Config.JWTAuthSecret = "mysecret"
 		Config.JWTAuthSigningMethod = "HS512"
-		Config.JWTAuthDebug = true
 		defer func() {
 			Config.JWTAuthEnabled = false
 			Config.JWTAuthSecret = ""


### PR DESCRIPTION
Added support for validating HS512 JWT tokens

## Description
added a hs512 case to handle the tokens

## Motivation and Context
We have JWT tokens signed by HS512 method. Its was throwing invalid signature. So had to add this extension

## How Has This Been Tested?
I have added tests with valid HS512 signed tokens
