### PR TITLE
Bump go-swagger

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ gen: api_docs swagger
 
 deps: checks
 	@GO111MODULE=off go get -u github.com/myitcv/gobin
-	@gobin github.com/go-swagger/go-swagger/cmd/swagger@v0.19.0
+	@gobin github.com/go-swagger/go-swagger/cmd/swagger@v0.20.1
 	@gobin github.com/codeskyblue/fswatch
 	@gobin github.com/golangci/golangci-lint/cmd/golangci-lint@v1.16.0
 	@echo "Sqlite3" && sqlite3 -version

--- a/docs/api_docs/bundle.yaml
+++ b/docs/api_docs/bundle.yaml
@@ -770,7 +770,7 @@ paths:
     get:
       tags:
         - export
-      operationId: getExportSQLite
+      operationId: getExportSqlite
       description: >-
         Export sqlite3 format of the db dump, which is converted from the main
         database.

--- a/integration_tests/test.sh
+++ b/integration_tests/test.sh
@@ -287,7 +287,6 @@ step_7_test_evaluation()
 step_8_test_preload()
 {
     flagr_url=$1:18000/api/v1
-    sleep 5
 
     ################################################
     # Test preload for /flags (depends on ?preload=true/false
@@ -312,6 +311,22 @@ step_8_test_preload()
         matches "\"variantID\":1"
 }
 
+step_9_test_export()
+{
+    flagr_url=$1:18000/api/v1
+
+    ################################################
+    # Test export
+    ################################################
+    shakedown GET $flagr_url/export/sqlite
+        status 200
+
+    shakedown GET $flagr_url/export/eval_cache/json
+        status 200
+        matches "\"VariantKey\":\"key_1\""
+        matches "\"VariantID\":1"
+}
+
 
 start_test()
 {
@@ -331,6 +346,7 @@ start_test()
     step_6_test_crud_distribution $flagr_host
     step_7_test_evaluation $flagr_host
     step_8_test_preload $flagr_host
+    step_9_test_export $flagr_host
 }
 
 start(){

--- a/pkg/handler/crud.go
+++ b/pkg/handler/crud.go
@@ -346,7 +346,7 @@ func (c *crud) PutSegment(params segment.PutSegmentParams) middleware.Responder 
 
 func (c *crud) PutSegmentsReorder(params segment.PutSegmentsReorderParams) middleware.Responder {
 	tx := getDB().Begin()
-	for i, segmentID := range params.Body.SegmentIds {
+	for i, segmentID := range params.Body.SegmentIDs {
 		s := &entity.Segment{}
 		if err := tx.First(s, segmentID).Error; err != nil {
 			tx.Rollback()

--- a/pkg/handler/crud_test.go
+++ b/pkg/handler/crud_test.go
@@ -457,7 +457,7 @@ func TestCrudSegments(t *testing.T) {
 	res = c.PutSegmentsReorder(segment.PutSegmentsReorderParams{
 		FlagID: int64(1),
 		Body: &models.PutSegmentReorderRequest{
-			SegmentIds: []int64{int64(2), int64(1)},
+			SegmentIDs: []int64{int64(2), int64(1)},
 		},
 	})
 	assert.NotZero(t, res.(*segment.PutSegmentsReorderOK))
@@ -525,7 +525,7 @@ func TestCrudSegmentsWithFailures(t *testing.T) {
 		res = c.PutSegmentsReorder(segment.PutSegmentsReorderParams{
 			FlagID: int64(1),
 			Body: &models.PutSegmentReorderRequest{
-				SegmentIds: []int64{int64(999998), int64(1)},
+				SegmentIDs: []int64{int64(999998), int64(1)},
 			},
 		})
 		assert.NotZero(t, res.(*segment.PutSegmentsReorderDefault).Payload)

--- a/pkg/handler/eval.go
+++ b/pkg/handler/eval.go
@@ -47,7 +47,7 @@ func (e *eval) PostEvaluation(params evaluation.PostEvaluationParams) middleware
 
 func (e *eval) PostEvaluationBatch(params evaluation.PostEvaluationBatchParams) middleware.Responder {
 	entities := params.Body.Entities
-	flagIDs := params.Body.FlagIds
+	flagIDs := params.Body.FlagIDs
 	flagKeys := params.Body.FlagKeys
 	results := &models.EvaluationBatchResponse{}
 

--- a/pkg/handler/eval_test.go
+++ b/pkg/handler/eval_test.go
@@ -373,7 +373,7 @@ func TestPostEvaluationBatch(t *testing.T) {
 						EntityType:    "entityType1",
 					},
 				},
-				FlagIds:  []int64{100, 200},
+				FlagIDs:  []int64{100, 200},
 				FlagKeys: []string{"flag_key_1", "flag_key_2"},
 			},
 		})

--- a/swagger/export_sqlite.yaml
+++ b/swagger/export_sqlite.yaml
@@ -1,7 +1,7 @@
 get:
   tags:
     - export
-  operationId: getExportSQLite
+  operationId: getExportSqlite
   description: Export sqlite3 format of the db dump, which is converted from the main database.
   produces:
     - application/octet-stream

--- a/swagger_gen/models/evaluation_batch_request.go
+++ b/swagger_gen/models/evaluation_batch_request.go
@@ -29,7 +29,7 @@ type EvaluationBatchRequest struct {
 
 	// flagIDs
 	// Min Items: 1
-	FlagIds []int64 `json:"flagIDs"`
+	FlagIDs []int64 `json:"flagIDs"`
 
 	// flagKeys. Either flagIDs or flagKeys works. If pass in both, Flagr may return duplicate results.
 	// Min Items: 1
@@ -44,7 +44,7 @@ func (m *EvaluationBatchRequest) Validate(formats strfmt.Registry) error {
 		res = append(res, err)
 	}
 
-	if err := m.validateFlagIds(formats); err != nil {
+	if err := m.validateFlagIDs(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -89,21 +89,21 @@ func (m *EvaluationBatchRequest) validateEntities(formats strfmt.Registry) error
 	return nil
 }
 
-func (m *EvaluationBatchRequest) validateFlagIds(formats strfmt.Registry) error {
+func (m *EvaluationBatchRequest) validateFlagIDs(formats strfmt.Registry) error {
 
-	if swag.IsZero(m.FlagIds) { // not required
+	if swag.IsZero(m.FlagIDs) { // not required
 		return nil
 	}
 
-	iFlagIdsSize := int64(len(m.FlagIds))
+	iFlagIDsSize := int64(len(m.FlagIDs))
 
-	if err := validate.MinItems("flagIDs", "body", iFlagIdsSize, 1); err != nil {
+	if err := validate.MinItems("flagIDs", "body", iFlagIDsSize, 1); err != nil {
 		return err
 	}
 
-	for i := 0; i < len(m.FlagIds); i++ {
+	for i := 0; i < len(m.FlagIDs); i++ {
 
-		if err := validate.MinimumInt("flagIDs"+"."+strconv.Itoa(i), "body", int64(m.FlagIds[i]), 1, false); err != nil {
+		if err := validate.MinimumInt("flagIDs"+"."+strconv.Itoa(i), "body", int64(m.FlagIDs[i]), 1, false); err != nil {
 			return err
 		}
 

--- a/swagger_gen/models/put_segment_reorder_request.go
+++ b/swagger_gen/models/put_segment_reorder_request.go
@@ -19,17 +19,17 @@ import (
 // swagger:model putSegmentReorderRequest
 type PutSegmentReorderRequest struct {
 
-	// segment ids
+	// segment i ds
 	// Required: true
 	// Min Items: 1
-	SegmentIds []int64 `json:"segmentIDs"`
+	SegmentIDs []int64 `json:"segmentIDs"`
 }
 
 // Validate validates this put segment reorder request
 func (m *PutSegmentReorderRequest) Validate(formats strfmt.Registry) error {
 	var res []error
 
-	if err := m.validateSegmentIds(formats); err != nil {
+	if err := m.validateSegmentIDs(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -39,21 +39,21 @@ func (m *PutSegmentReorderRequest) Validate(formats strfmt.Registry) error {
 	return nil
 }
 
-func (m *PutSegmentReorderRequest) validateSegmentIds(formats strfmt.Registry) error {
+func (m *PutSegmentReorderRequest) validateSegmentIDs(formats strfmt.Registry) error {
 
-	if err := validate.Required("segmentIDs", "body", m.SegmentIds); err != nil {
+	if err := validate.Required("segmentIDs", "body", m.SegmentIDs); err != nil {
 		return err
 	}
 
-	iSegmentIdsSize := int64(len(m.SegmentIds))
+	iSegmentIDsSize := int64(len(m.SegmentIDs))
 
-	if err := validate.MinItems("segmentIDs", "body", iSegmentIdsSize, 1); err != nil {
+	if err := validate.MinItems("segmentIDs", "body", iSegmentIDsSize, 1); err != nil {
 		return err
 	}
 
-	for i := 0; i < len(m.SegmentIds); i++ {
+	for i := 0; i < len(m.SegmentIDs); i++ {
 
-		if err := validate.MinimumInt("segmentIDs"+"."+strconv.Itoa(i), "body", int64(m.SegmentIds[i]), 1, false); err != nil {
+		if err := validate.MinimumInt("segmentIDs"+"."+strconv.Itoa(i), "body", int64(m.SegmentIDs[i]), 1, false); err != nil {
 			return err
 		}
 

--- a/swagger_gen/restapi/configure_flagr.go
+++ b/swagger_gen/restapi/configure_flagr.go
@@ -17,7 +17,7 @@ import (
 
 // This file is safe to edit. Once it exists it will not be overwritten
 
-//go:generate swagger generate server --target ../swagger_gen --name  --spec ../swagger.yml
+//go:generate swagger generate server --target ../../swagger_gen --name Flagr --spec ../../docs/api_docs/bundle.yaml
 
 func configureFlags(api *operations.FlagrAPI) {
 	// api.CommandLineOptionsGroups = []swag.CommandLineOptionsGroup{ ... }
@@ -28,6 +28,8 @@ func configureAPI(api *operations.FlagrAPI) http.Handler {
 
 	api.JSONConsumer = runtime.JSONConsumer()
 	api.JSONProducer = runtime.JSONProducer()
+	api.BinProducer = runtime.ByteStreamProducer()
+
 	api.Logger = logrus.Infof
 	api.ServerShutdown = config.ServerShutdown
 

--- a/swagger_gen/restapi/embedded_spec.go
+++ b/swagger_gen/restapi/embedded_spec.go
@@ -136,7 +136,7 @@ func init() {
         "tags": [
           "export"
         ],
-        "operationId": "getExportSQLite",
+        "operationId": "getExportSqlite",
         "responses": {
           "200": {
             "description": "OK",
@@ -1909,7 +1909,7 @@ func init() {
         "tags": [
           "export"
         ],
-        "operationId": "getExportSQLite",
+        "operationId": "getExportSqlite",
         "responses": {
           "200": {
             "description": "OK",

--- a/swagger_gen/restapi/operations/export/get_export_sqlite_parameters.go
+++ b/swagger_gen/restapi/operations/export/get_export_sqlite_parameters.go
@@ -22,7 +22,7 @@ func NewGetExportSqliteParams() GetExportSqliteParams {
 // GetExportSqliteParams contains all the bound params for the get export sqlite operation
 // typically these are obtained from a http.Request
 //
-// swagger:parameters getExportSQLite
+// swagger:parameters getExportSqlite
 type GetExportSqliteParams struct {
 
 	// HTTP Request Object

--- a/swagger_gen/restapi/operations/flag/find_flags_urlbuilder.go
+++ b/swagger_gen/restapi/operations/flag/find_flags_urlbuilder.go
@@ -57,60 +57,60 @@ func (o *FindFlagsURL) Build() (*url.URL, error) {
 
 	qs := make(url.Values)
 
-	var description string
+	var descriptionQ string
 	if o.Description != nil {
-		description = *o.Description
+		descriptionQ = *o.Description
 	}
-	if description != "" {
-		qs.Set("description", description)
+	if descriptionQ != "" {
+		qs.Set("description", descriptionQ)
 	}
 
-	var descriptionLike string
+	var descriptionLikeQ string
 	if o.DescriptionLike != nil {
-		descriptionLike = *o.DescriptionLike
+		descriptionLikeQ = *o.DescriptionLike
 	}
-	if descriptionLike != "" {
-		qs.Set("description_like", descriptionLike)
+	if descriptionLikeQ != "" {
+		qs.Set("description_like", descriptionLikeQ)
 	}
 
-	var enabled string
+	var enabledQ string
 	if o.Enabled != nil {
-		enabled = swag.FormatBool(*o.Enabled)
+		enabledQ = swag.FormatBool(*o.Enabled)
 	}
-	if enabled != "" {
-		qs.Set("enabled", enabled)
+	if enabledQ != "" {
+		qs.Set("enabled", enabledQ)
 	}
 
-	var key string
+	var keyQ string
 	if o.Key != nil {
-		key = *o.Key
+		keyQ = *o.Key
 	}
-	if key != "" {
-		qs.Set("key", key)
+	if keyQ != "" {
+		qs.Set("key", keyQ)
 	}
 
-	var limit string
+	var limitQ string
 	if o.Limit != nil {
-		limit = swag.FormatInt64(*o.Limit)
+		limitQ = swag.FormatInt64(*o.Limit)
 	}
-	if limit != "" {
-		qs.Set("limit", limit)
+	if limitQ != "" {
+		qs.Set("limit", limitQ)
 	}
 
-	var offset string
+	var offsetQ string
 	if o.Offset != nil {
-		offset = swag.FormatInt64(*o.Offset)
+		offsetQ = swag.FormatInt64(*o.Offset)
 	}
-	if offset != "" {
-		qs.Set("offset", offset)
+	if offsetQ != "" {
+		qs.Set("offset", offsetQ)
 	}
 
-	var preload string
+	var preloadQ string
 	if o.Preload != nil {
-		preload = swag.FormatBool(*o.Preload)
+		preloadQ = swag.FormatBool(*o.Preload)
 	}
-	if preload != "" {
-		qs.Set("preload", preload)
+	if preloadQ != "" {
+		qs.Set("preload", preloadQ)
 	}
 
 	_result.RawQuery = qs.Encode()

--- a/swagger_gen/restapi/server.go
+++ b/swagger_gen/restapi/server.go
@@ -133,7 +133,6 @@ func (s *Server) SetAPI(api *operations.FlagrAPI) {
 	}
 
 	s.api = api
-	s.api.Logger = log.Printf
 	s.handler = configureAPI(api)
 }
 
@@ -252,7 +251,7 @@ func (s *Server) Serve() (err error) {
 			// https://github.com/golang/go/tree/master/src/crypto/elliptic
 			CurvePreferences: []tls.CurveID{tls.CurveP256},
 			// Use modern tls mode https://wiki.mozilla.org/Security/Server_Side_TLS#Modern_compatibility
-			NextProtos: []string{"http/1.1", "h2"},
+			NextProtos: []string{"h2", "http/1.1"},
 			// https://www.owasp.org/index.php/Transport_Layer_Protection_Cheat_Sheet#Rule_-_Only_Support_Strong_Protocols
 			MinVersion: tls.VersionTLS12,
 			// These ciphersuites support Forward Secrecy: https://en.wikipedia.org/wiki/Forward_secrecy
@@ -293,7 +292,7 @@ func (s *Server) Serve() (err error) {
 		// call custom TLS configurator
 		configureTLS(httpsServer.TLSConfig)
 
-		if len(httpsServer.TLSConfig.Certificates) == 0 {
+		if len(httpsServer.TLSConfig.Certificates) == 0 && httpsServer.TLSConfig.GetCertificate == nil {
 			// after standard and custom config are passed, this ends up with no certificate
 			if s.TLSCertificate == "" {
 				if s.TLSCertificateKey == "" {


### PR DESCRIPTION
Bump to latest go-swagger@0.20.1. Fixed some breaking changes. Note that there are no changes to the flagr APIs at all. Just some variables renaming internally.

Fix https://github.com/checkr/flagr/issues/283