### PR TITLE
feat: Put EvalFlag public

### DIFF
--- a/pkg/handler/eval.go
+++ b/pkg/handler/eval.go
@@ -39,7 +39,7 @@ func (e *eval) PostEvaluation(params evaluation.PostEvaluationParams) middleware
 			ErrorMessage("empty body"))
 	}
 
-	evalResult := evalFlag(*evalContext)
+	evalResult := EvalFlag(*evalContext)
 	resp := evaluation.NewPostEvaluationOK()
 	resp.SetPayload(evalResult)
 	return resp
@@ -61,7 +61,7 @@ func (e *eval) PostEvaluationBatch(params evaluation.PostEvaluationBatchParams) 
 				EntityType:    entity.EntityType,
 				FlagID:        flagID,
 			}
-			evalResult := evalFlag(evalContext)
+			evalResult := EvalFlag(evalContext)
 			results.EvaluationResults = append(results.EvaluationResults, evalResult)
 		}
 		for _, flagKey := range flagKeys {
@@ -72,7 +72,7 @@ func (e *eval) PostEvaluationBatch(params evaluation.PostEvaluationBatchParams) 
 				EntityType:    entity.EntityType,
 				FlagKey:       flagKey,
 			}
-			evalResult := evalFlag(evalContext)
+			evalResult := EvalFlag(evalContext)
 			results.EvaluationResults = append(results.EvaluationResults, evalResult)
 		}
 	}
@@ -105,7 +105,7 @@ func BlankResult(f *entity.Flag, evalContext models.EvalContext, msg string) *mo
 	}
 }
 
-var evalFlag = func(evalContext models.EvalContext) *models.EvalResult {
+var EvalFlag = func(evalContext models.EvalContext) *models.EvalResult {
 	cache := GetEvalCache()
 	flagID := util.SafeUint(evalContext.FlagID)
 	flagKey := util.SafeString(evalContext.FlagKey)

--- a/pkg/handler/eval_test.go
+++ b/pkg/handler/eval_test.go
@@ -146,7 +146,7 @@ func TestEvalFlag(t *testing.T) {
 
 	t.Run("test empty evalContext", func(t *testing.T) {
 		defer gostub.StubFunc(&GetEvalCache, GenFixtureEvalCache()).Reset()
-		result := evalFlag(models.EvalContext{FlagID: int64(100)})
+		result := EvalFlag(models.EvalContext{FlagID: int64(100)})
 		assert.Zero(t, result.VariantID)
 		assert.NotZero(t, result.FlagID)
 		assert.NotEmpty(t, result.EvalContext.EntityID)
@@ -154,7 +154,7 @@ func TestEvalFlag(t *testing.T) {
 
 	t.Run("test happy code path", func(t *testing.T) {
 		defer gostub.StubFunc(&GetEvalCache, GenFixtureEvalCache()).Reset()
-		result := evalFlag(models.EvalContext{
+		result := EvalFlag(models.EvalContext{
 			EnableDebug:   true,
 			EntityContext: map[string]interface{}{"dl_state": "CA"},
 			EntityID:      "entityID1",
@@ -167,7 +167,7 @@ func TestEvalFlag(t *testing.T) {
 
 	t.Run("test happy code path with flagKey", func(t *testing.T) {
 		defer gostub.StubFunc(&GetEvalCache, GenFixtureEvalCache()).Reset()
-		result := evalFlag(models.EvalContext{
+		result := EvalFlag(models.EvalContext{
 			EnableDebug:   true,
 			EntityContext: map[string]interface{}{"dl_state": "CA"},
 			EntityID:      "entityID1",
@@ -180,7 +180,7 @@ func TestEvalFlag(t *testing.T) {
 
 	t.Run("test happy code path with flagKey", func(t *testing.T) {
 		defer gostub.StubFunc(&GetEvalCache, GenFixtureEvalCache()).Reset()
-		result := evalFlag(models.EvalContext{
+		result := EvalFlag(models.EvalContext{
 			EnableDebug:   true,
 			EntityContext: map[string]interface{}{"dl_state": "CA"},
 			EntityID:      "entityID1",
@@ -219,7 +219,7 @@ func TestEvalFlag(t *testing.T) {
 		f.PrepareEvaluation()
 		cache := &EvalCache{idCache: map[string]*entity.Flag{"100": &f}}
 		defer gostub.StubFunc(&GetEvalCache, cache).Reset()
-		result := evalFlag(models.EvalContext{
+		result := EvalFlag(models.EvalContext{
 			EnableDebug:   true,
 			EntityContext: map[string]interface{}{"dl_state": "CA", "state": "CA", "rate": 2000},
 			EntityID:      "entityID1",
@@ -239,7 +239,7 @@ func TestEvalFlag(t *testing.T) {
 		f.PrepareEvaluation()
 		cache := &EvalCache{idCache: map[string]*entity.Flag{"100": &f}}
 		defer gostub.StubFunc(&GetEvalCache, cache).Reset()
-		result := evalFlag(models.EvalContext{
+		result := EvalFlag(models.EvalContext{
 			EnableDebug:   true,
 			EntityContext: map[string]interface{}{"dl_state": "CA", "state": "CA", "rate": 2000},
 			EntityID:      "entityID1",
@@ -271,7 +271,7 @@ func TestEvalFlag(t *testing.T) {
 		f.PrepareEvaluation()
 		cache := &EvalCache{idCache: map[string]*entity.Flag{"100": &f}}
 		defer gostub.StubFunc(&GetEvalCache, cache).Reset()
-		result := evalFlag(models.EvalContext{
+		result := EvalFlag(models.EvalContext{
 			EnableDebug:   true,
 			EntityContext: map[string]interface{}{"dl_state": "CA", "state": "NY"},
 			EntityID:      "entityID1",
@@ -287,7 +287,7 @@ func TestEvalFlag(t *testing.T) {
 		f.Enabled = false
 		cache := &EvalCache{idCache: map[string]*entity.Flag{"100": &f}}
 		defer gostub.StubFunc(&GetEvalCache, cache).Reset()
-		result := evalFlag(models.EvalContext{
+		result := EvalFlag(models.EvalContext{
 			EnableDebug:   true,
 			EntityContext: map[string]interface{}{"dl_state": "CA"},
 			EntityID:      "entityID1",
@@ -304,7 +304,7 @@ func TestEvalFlag(t *testing.T) {
 			f.EntityType = ""
 			cache := &EvalCache{idCache: map[string]*entity.Flag{"100": &f}}
 			defer gostub.StubFunc(&GetEvalCache, cache).Reset()
-			result := evalFlag(models.EvalContext{
+			result := EvalFlag(models.EvalContext{
 				EnableDebug:   true,
 				EntityContext: map[string]interface{}{"dl_state": "CA"},
 				EntityID:      "entityID1",
@@ -320,7 +320,7 @@ func TestEvalFlag(t *testing.T) {
 			f.EntityType = "some_entity_type"
 			cache := &EvalCache{idCache: map[string]*entity.Flag{"100": &f}}
 			defer gostub.StubFunc(&GetEvalCache, cache).Reset()
-			result := evalFlag(models.EvalContext{
+			result := EvalFlag(models.EvalContext{
 				EnableDebug:   true,
 				EntityContext: map[string]interface{}{"dl_state": "CA"},
 				EntityID:      "entityID1",
@@ -337,14 +337,14 @@ func TestEvalFlag(t *testing.T) {
 
 func TestPostEvaluation(t *testing.T) {
 	t.Run("test empty body", func(t *testing.T) {
-		defer gostub.StubFunc(&evalFlag, &models.EvalResult{}).Reset()
+		defer gostub.StubFunc(&EvalFlag, &models.EvalResult{}).Reset()
 		e := NewEval()
 		resp := e.PostEvaluation(evaluation.PostEvaluationParams{})
 		assert.NotNil(t, resp)
 	})
 
 	t.Run("test happy code path", func(t *testing.T) {
-		defer gostub.StubFunc(&evalFlag, &models.EvalResult{}).Reset()
+		defer gostub.StubFunc(&EvalFlag, &models.EvalResult{}).Reset()
 		e := NewEval()
 		resp := e.PostEvaluation(evaluation.PostEvaluationParams{
 			Body: &models.EvalContext{
@@ -361,7 +361,7 @@ func TestPostEvaluation(t *testing.T) {
 
 func TestPostEvaluationBatch(t *testing.T) {
 	t.Run("test happy code path", func(t *testing.T) {
-		defer gostub.StubFunc(&evalFlag, &models.EvalResult{}).Reset()
+		defer gostub.StubFunc(&EvalFlag, &models.EvalResult{}).Reset()
 		e := NewEval()
 		resp := e.PostEvaluationBatch(evaluation.PostEvaluationBatchParams{
 			Body: &models.EvaluationBatchRequest{


### PR DESCRIPTION
In order to use flagr as a go package, EvalFlag should be public.

ref #298

## Description
I put evalFlag public

## Motivation and Context
As I work with flagr as a go package, to implement my own evaluator base on flagr solution. EvalFlag was the only function that needed to be public and was not. (see #298 )

## How Has This Been Tested?
The test have been updated, but they don;t need to be changed

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added/updated tests to cover my changes.
- [x] All new and existing tests passed.