### PR TITLE
Remove fmt.Println from Prometheus middleware

### DIFF
--- a/pkg/config/middleware.go
+++ b/pkg/config/middleware.go
@@ -245,7 +245,6 @@ func (p *prometheusMiddleware) ServeHTTP(w http.ResponseWriter, r *http.Request,
 			response := w.(negroni.ResponseWriter)
 			status := strconv.Itoa(response.Status())
 			duration := float64(time.Since(start)) / float64(time.Second)
-			fmt.Println(duration)
 
 			p.counter.WithLabelValues(status, r.RequestURI, r.Method).Inc()
 			if p.latencies != nil {


### PR DESCRIPTION
## Description
Removes a stray `fmt.Println` from the Prometheus middleware.

## Motivation and Context
With the Prometheus middleware enabled (using the Docker image with `FLAGR_PROMETHEUS_ENABLED="true"`), this is flooding our logs with float values like:

```
0.000139925
0.000169531
0.000258753
0.000200045
0.000197314
0.00013287
0.000159397
7.7382e-05
0.000159737
... etc
```

## How Has This Been Tested?
Built and deployed a canary Docker image with this change, checked that the values were no longer being output to stdout.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.