### PR TITLE
Allow slashes in the flag name regex

### DIFF
--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -12,7 +12,7 @@ import (
 
 var (
 	keyLengthLimit = 63
-	keyRegex       = regexp.MustCompile(`^[\w\d-]+$`)
+	keyRegex       = regexp.MustCompile(`^[\w\d-/]+$`)
 
 	randomKeyCharset = []byte("123456789abcdefghijkmnopqrstuvwxyz")
 	randomKeyPrefix  = "k"

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -96,6 +96,10 @@ func TestIsSafeKey(t *testing.T) {
 	b, msg = IsSafeKey(strings.Repeat("a", 64))
 	assert.False(t, b)
 	assert.NotEmpty(t, msg)
+
+	b, msg = IsSafeKey("slashes/are/valid")
+	assert.True(t, b)
+	assert.Empty(t, msg)
 }
 
 func TestPtrs(t *testing.T) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Upstream issue: https://github.com/checkr/flagr/issues/315
## Description
<!--- Describe your changes in detail -->
Allows you to add a as a valid character in a flag name to allow for sensible namespacing

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Allows people to namespace in a unix type fashion that makes it clear where the namespace ends and the flag begins

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally against existing postgres database; was able to update a flag and then get the flag back successfully

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.