### PR TITLE
Add better error checking around 404s and actual database errors

### DIFF
--- a/pkg/handler/crud.go
+++ b/pkg/handler/crud.go
@@ -152,11 +152,11 @@ func (c *crud) GetFlag(params flag.GetFlagParams) middleware.Responder {
 	// Flag with given ID doesn't exist, so we 404
 	if result.RecordNotFound() {
 		return flag.NewGetFlagDefault(404).WithPayload(
-			ErrorMessage("Unable to find flag %v in the database", params.FlagID))
+			ErrorMessage("unable to find flag %v in the database", params.FlagID))
 	}
 
 	// Something else happened, return a 500
-	if  err := result.Error; err != nil {
+	if err := result.Error; err != nil {
 		return flag.NewGetFlagDefault(500).WithPayload(
 			ErrorMessage("an unknown error occurred while looking up flag %v: %s", params.FlagID, err))
 	}

--- a/pkg/handler/crud.go
+++ b/pkg/handler/crud.go
@@ -147,10 +147,18 @@ func (c *crud) CreateFlag(params flag.CreateFlagParams) middleware.Responder {
 
 func (c *crud) GetFlag(params flag.GetFlagParams) middleware.Responder {
 	f := &entity.Flag{}
-	err := entity.PreloadSegmentsVariants(getDB()).First(f, params.FlagID).Error
-	if err != nil {
+	result := entity.PreloadSegmentsVariants(getDB()).First(f, params.FlagID)
+
+	// Flag with given ID doesn't exist, so we 404
+	if result.RecordNotFound() {
 		return flag.NewGetFlagDefault(404).WithPayload(
-			ErrorMessage("cannot find flag %v. %s", params.FlagID, err))
+			ErrorMessage("Unable to find flag %v in the database", params.FlagID))
+	}
+
+	// Something else happened, return a 500
+	if  err := result.Error; err != nil {
+		return flag.NewGetFlagDefault(500).WithPayload(
+			ErrorMessage("An unknown error occurred while looking up flag %v: %s", params.FlagID, err))
 	}
 
 	resp := flag.NewGetFlagOK()

--- a/pkg/handler/crud.go
+++ b/pkg/handler/crud.go
@@ -158,7 +158,7 @@ func (c *crud) GetFlag(params flag.GetFlagParams) middleware.Responder {
 	// Something else happened, return a 500
 	if  err := result.Error; err != nil {
 		return flag.NewGetFlagDefault(500).WithPayload(
-			ErrorMessage("An unknown error occurred while looking up flag %v: %s", params.FlagID, err))
+			ErrorMessage("an unknown error occurred while looking up flag %v: %s", params.FlagID, err))
 	}
 
 	resp := flag.NewGetFlagOK()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This change does an explicit check for a RecordNotFound error and returns a 404 only in that case; returning 500 in other cases

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #317 

> Currently, in the case that the database is removed from behind a running instance of flagr (network connection, password change, etc) the application returns a 404 to a GET request on localhost:13480/api/v1/flags/1000

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally by starting up an instance of flagr, verifying functionality, removing the backing database and then attempting to get the same flag again.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

I don't believe there are tests covering this particular kind of failure case in `crud_tests.go` but I might have missed them - please do point it out and I'll add them if so