### PR TITLE
Fix golangci-lint for context string key unittest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ deps: checks
 	@GO111MODULE=off go get -u github.com/myitcv/gobin
 	@gobin github.com/go-swagger/go-swagger/cmd/swagger@v0.21.0
 	@gobin github.com/codeskyblue/fswatch
-	@gobin github.com/golangci/golangci-lint/cmd/golangci-lint
+	@gobin github.com/golangci/golangci-lint/cmd/golangci-lint@v1.24.0
 	@echo "Sqlite3" && sqlite3 -version
 
 watch:

--- a/pkg/handler/subject_test.go
+++ b/pkg/handler/subject_test.go
@@ -1,4 +1,3 @@
-
 package handler
 
 import (
@@ -23,10 +22,12 @@ func TestGetSubjectFromJWT(t *testing.T) {
 	ctx = context.TODO()
 	assert.Equal(t, getSubjectFromRequest(r.WithContext(ctx)), "")
 
-	ctx = context.WithValue(ctx, interface{}(config.Config.JWTAuthUserProperty), &jwt.Token{})
+	//nolint:staticcheck // jwt-middleware is using the string type of context key
+	ctx = context.WithValue(ctx, config.Config.JWTAuthUserProperty, &jwt.Token{})
 	assert.Equal(t, getSubjectFromRequest(r.WithContext(ctx)), "")
 
-	ctx = context.WithValue(ctx, interface{}(config.Config.JWTAuthUserProperty), &jwt.Token{
+	//nolint:staticcheck // jwt-middleware is using the string type of context key
+	ctx = context.WithValue(ctx, config.Config.JWTAuthUserProperty, &jwt.Token{
 		Claims: jwt.MapClaims{
 			"sub": "foo@example.com",
 		},


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
Fix golangci-lint:

```
#!/bin/bash -eo pipefail
make ci
Running verify_lint
pkg/handler/subject_test.go:26:31: SA1029: should not use built-in type string as key for value; define your own type to avoid collisions (staticcheck)
	ctx = context.WithValue(ctx, interface{}(config.Config.JWTAuthUserProperty), &jwt.Token{})
	                             ^
pkg/handler/subject_test.go:29:31: SA1029: should not use built-in type string as key for value; define your own type to avoid collisions (staticcheck)
	ctx = context.WithValue(ctx, interface{}(config.Config.JWTAuthUserProperty), &jwt.Token{
	                             ^
make: *** [Makefile:66: verify_lint] Error 1

Exited with code exit status 2
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.