### PR TITLE
Fix enabled query param

### DIFF
--- a/pkg/handler/crud.go
+++ b/pkg/handler/crud.go
@@ -75,7 +75,7 @@ func (c *crud) FindFlags(params flag.FindFlagsParams) middleware.Responder {
 	q := entity.Flag{}
 
 	if params.Enabled != nil {
-		q.Enabled = *params.Enabled
+		tx = tx.Where("enabled = ?", *params.Enabled)
 	}
 	if params.Description != nil {
 		q.Description = *params.Description

--- a/pkg/handler/crud_test.go
+++ b/pkg/handler/crud_test.go
@@ -47,6 +47,24 @@ func TestCrudFlags(t *testing.T) {
 		assert.NotZero(t, len(res.(*flag.FindFlagsOK).Payload))
 	})
 
+	t.Run("it should respect the ?enabled query param", func(t *testing.T) {
+		res = c.FindFlags(flag.FindFlagsParams{})
+		allFlags := len(res.(*flag.FindFlagsOK).Payload)
+
+		res = c.FindFlags(flag.FindFlagsParams{
+			Enabled: util.BoolPtr(true),
+		})
+		enabledFlags := len(res.(*flag.FindFlagsOK).Payload)
+
+		res = c.FindFlags(flag.FindFlagsParams{
+			Enabled: util.BoolPtr(false),
+		})
+		disabledFlags := len(res.(*flag.FindFlagsOK).Payload)
+
+		assert.Equal(t, allFlags, enabledFlags+disabledFlags)
+		assert.NotEqual(t, allFlags, enabledFlags)
+	})
+
 	t.Run("it should be able to get the flag after creation", func(t *testing.T) {
 		res = c.GetFlag(flag.GetFlagParams{FlagID: int64(1)})
 		assert.NotZero(t, res.(*flag.GetFlagOK).Payload.ID)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fix #342 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Tested locally.

- `/api/v1/flags` returns all
- `/api/v1/flags?enabled=true` returns enabled ones
- `/api/v1/flags?enabled=false` returns disabled ones

I think the boolean parameter binding from go-swagger also allows `?enabled=t` or `?enabled=f`.  

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.