### PR TITLE
Support additional characters for flag keys

### DIFF
--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -12,7 +12,7 @@ import (
 
 var (
 	keyLengthLimit = 63
-	keyRegex       = regexp.MustCompile(`^[\w\d-/]+$`)
+	keyRegex       = regexp.MustCompile(`^[\w\d-/\.\:]+$`)
 
 	randomKeyCharset = []byte("123456789abcdefghijkmnopqrstuvwxyz")
 	randomKeyPrefix  = "k"

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -100,6 +100,14 @@ func TestIsSafeKey(t *testing.T) {
 	b, msg = IsSafeKey("slashes/are/valid")
 	assert.True(t, b)
 	assert.Empty(t, msg)
+
+	b, msg = IsSafeKey("dots.are.valid")
+	assert.True(t, b)
+	assert.Empty(t, msg)
+
+	b, msg = IsSafeKey("colons:are:valid")
+	assert.True(t, b)
+	assert.Empty(t, msg)
 }
 
 func TestPtrs(t *testing.T) {


### PR DESCRIPTION
Add support for `:` and `.` characters.

Fixes #347 