### PR TITLE
Add basic auth support for interface

### DIFF
--- a/docs/flagr_env.md
+++ b/docs/flagr_env.md
@@ -65,3 +65,11 @@ The best way to configure service account for Flagr to use pubsub only use:
 FLAGR_RECORDER_PUBSUB_PROJECT_ID=google-project-id
 FLAGR_RECORDER_PUBSUB_KEYFILE=/path/to/service/account.json
 ```
+
+Basic Authentication for web interface
+
+```
+FLAGR_BASIC_AUTH_ENABLED=true
+FLAGR_BASIC_AUTH_USERNAME=admin
+FLAGR_BASIC_AUTH_PASSWORD=password
+```

--- a/docs/flagr_env.md
+++ b/docs/flagr_env.md
@@ -73,3 +73,12 @@ FLAGR_BASIC_AUTH_ENABLED=true
 FLAGR_BASIC_AUTH_USERNAME=admin
 FLAGR_BASIC_AUTH_PASSWORD=password
 ```
+
+By default, UI access will prompt for a username/password login. Similar to JWT Auth, prefix and exact paths can be whitelisted to skip the username/password login. The default whitelist will allow api access to `/api/v1/flags` and `/api/v1/evaluation*`
+
+NOTE: this doesn't prevent people from directly curling /api/v1/flags to update flags.
+
+```
+FLAGR_BASIC_AUTH_WHITELIST_PATHS="/api/v1/flags,/api/v1/evaluation"
+FLAGR_BASIC_AUTH_EXACT_WHITELIST_PATHS=""
+```

--- a/pkg/config/env.go
+++ b/pkg/config/env.go
@@ -193,7 +193,7 @@ var Config = struct {
 	BasicAuthEnabled              bool     `env:"FLAGR_BASIC_AUTH_ENABLED" envDefault:"false"`
 	BasicAuthUsername             string   `env:"FLAGR_BASIC_AUTH_USERNAME" envDefault:""`
 	BasicAuthPassword             string   `env:"FLAGR_BASIC_AUTH_PASSWORD" envDefault:""`
-	BasicAuthPrefixWhitelistPaths []string `env:"FLAGR_BASIC_AUTH_WHITELIST_PATHS" envDefault:"/api/v1/flags,/api/v1/evaluation,/api/v1/evaluation/batch" envSeparator:","`
+	BasicAuthPrefixWhitelistPaths []string `env:"FLAGR_BASIC_AUTH_WHITELIST_PATHS" envDefault:"/api/v1/flags,/api/v1/evaluation" envSeparator:","`
 	BasicAuthExactWhitelistPaths  []string `env:"FLAGR_BASIC_AUTH_EXACT_WHITELIST_PATHS" envDefault:"" envSeparator:","`
 
 	// WebPrefix - base path for web and API

--- a/pkg/config/env.go
+++ b/pkg/config/env.go
@@ -190,9 +190,9 @@ var Config = struct {
 	HeaderAuthUserField string `env:"FLAGR_HEADER_AUTH_USER_FIELD" envDefault:"X-Email"`
 
 	// Authenticate with basic auth
-	BasicAuthEnabled              bool     `env:"BASIC_AUTH_ENABLED" envDefault:"false"`
-	BasicAuthUsername             string   `env:"BASIC_AUTH_USERNAME" envDefault:""`
-	BasicAuthPassword             string   `env:"BASIC_AUTH_PASSWORD" envDefault:""`
+	BasicAuthEnabled              bool     `env:"FLAGR_BASIC_AUTH_ENABLED" envDefault:"false"`
+	BasicAuthUsername             string   `env:"FLAGR_BASIC_AUTH_USERNAME" envDefault:""`
+	BasicAuthPassword             string   `env:"FLAGR_BASIC_AUTH_PASSWORD" envDefault:""`
 	BasicAuthPrefixWhitelistPaths []string `env:"FLAGR_BASIC_AUTH_WHITELIST_PATHS" envDefault:"/api/v1/evaluation,/static" envSeparator:","`
 	BasicAuthExactWhitelistPaths  []string `env:"FLAGR_BASIC_AUTH_EXACT_WHITELIST_PATHS" envDefault:",/" envSeparator:","`
 

--- a/pkg/config/env.go
+++ b/pkg/config/env.go
@@ -193,8 +193,8 @@ var Config = struct {
 	BasicAuthEnabled              bool     `env:"FLAGR_BASIC_AUTH_ENABLED" envDefault:"false"`
 	BasicAuthUsername             string   `env:"FLAGR_BASIC_AUTH_USERNAME" envDefault:""`
 	BasicAuthPassword             string   `env:"FLAGR_BASIC_AUTH_PASSWORD" envDefault:""`
-	BasicAuthPrefixWhitelistPaths []string `env:"FLAGR_BASIC_AUTH_WHITELIST_PATHS" envDefault:"/api/v1/evaluation,/static" envSeparator:","`
-	BasicAuthExactWhitelistPaths  []string `env:"FLAGR_BASIC_AUTH_EXACT_WHITELIST_PATHS" envDefault:",/" envSeparator:","`
+	BasicAuthPrefixWhitelistPaths []string `env:"FLAGR_BASIC_AUTH_WHITELIST_PATHS" envDefault:"/api/v1/flags,/api/v1/evaluation,/api/v1/evaluation/batch" envSeparator:","`
+	BasicAuthExactWhitelistPaths  []string `env:"FLAGR_BASIC_AUTH_EXACT_WHITELIST_PATHS" envDefault:"" envSeparator:","`
 
 	// WebPrefix - base path for web and API
 	// e.g. FLAGR_WEB_PREFIX=/foo

--- a/pkg/config/env.go
+++ b/pkg/config/env.go
@@ -189,6 +189,13 @@ var Config = struct {
 	HeaderAuthEnabled   bool   `env:"FLAGR_HEADER_AUTH_ENABLED" envDefault:"false"`
 	HeaderAuthUserField string `env:"FLAGR_HEADER_AUTH_USER_FIELD" envDefault:"X-Email"`
 
+	// Authenticate with basic auth
+	BasicAuthEnabled              bool     `env:"BASIC_AUTH_ENABLED" envDefault:"false"`
+	BasicAuthUsername             string   `env:"BASIC_AUTH_USERNAME" envDefault:""`
+	BasicAuthPassword             string   `env:"BASIC_AUTH_PASSWORD" envDefault:""`
+	BasicAuthPrefixWhitelistPaths []string `env:"FLAGR_BASIC_AUTH_WHITELIST_PATHS" envDefault:"/api/v1/evaluation,/static" envSeparator:","`
+	BasicAuthExactWhitelistPaths  []string `env:"FLAGR_BASIC_AUTH_EXACT_WHITELIST_PATHS" envDefault:",/" envSeparator:","`
+
 	// WebPrefix - base path for web and API
 	// e.g. FLAGR_WEB_PREFIX=/foo
 	// UI path  => localhost:18000/foo"

--- a/pkg/config/middleware_test.go
+++ b/pkg/config/middleware_test.go
@@ -58,7 +58,7 @@ func TestSetupGlobalMiddleware(t *testing.T) {
 	Config.PProfEnabled = true
 }
 
-func TestAuthMiddleware(t *testing.T) {
+func TestJWTAuthMiddleware(t *testing.T) {
 	h := &okHandler{}
 
 	t.Run("it will redirect if jwt enabled but no cookie passed", func(t *testing.T) {
@@ -255,7 +255,7 @@ o2kQ+X5xK9cipRgEKwIDAQAB
 	})
 }
 
-func TestAuthMiddlewareWithUnauthorized(t *testing.T) {
+func TestJWTAuthMiddlewareWithUnauthorized(t *testing.T) {
 	h := &okHandler{}
 
 	t.Run("it will return 401 if no cookie passed", func(t *testing.T) {
@@ -311,6 +311,65 @@ func TestAuthMiddlewareWithUnauthorized(t *testing.T) {
 				req, _ := http.NewRequest("GET", fmt.Sprintf("http://localhost:18000%s", path), nil)
 				hh.ServeHTTP(res, req)
 				assert.Equal(t, http.StatusOK, res.Code)
+			})
+		}
+	})
+}
+
+func TestBasicAuthMiddleware(t *testing.T) {
+	h := &okHandler{}
+
+	t.Run("it will return 200 for web paths when disabled", func(t *testing.T) {
+		testPaths := []string{"/", "", "/#", "/#/", "/static", "/static/"}
+		for _, path := range testPaths {
+			t.Run(fmt.Sprintf("path: %s", path), func(t *testing.T) {
+				hh := SetupGlobalMiddleware(h)
+				res := httptest.NewRecorder()
+				res.Body = new(bytes.Buffer)
+				req, _ := http.NewRequest("GET", fmt.Sprintf("http://localhost:18000%s", path), nil)
+				hh.ServeHTTP(res, req)
+				assert.Equal(t, http.StatusOK, res.Code)
+			})
+		}
+	})
+
+	t.Run("it will return 200 for whitelist path if basic auth is enabled", func(t *testing.T) {
+		Config.BasicAuthEnabled = true
+		Config.BasicAuthUsername = "admin"
+		Config.BasicAuthPassword = "password"
+		defer func() {
+			Config.BasicAuthEnabled = false
+			Config.BasicAuthUsername = ""
+			Config.BasicAuthPassword = ""
+		}()
+
+		hh := SetupGlobalMiddleware(h)
+		res := httptest.NewRecorder()
+		res.Body = new(bytes.Buffer)
+		req, _ := http.NewRequest("GET", "http://localhost:18000/api/v1/flags", nil)
+		hh.ServeHTTP(res, req)
+		assert.Equal(t, http.StatusOK, res.Code)
+	})
+
+	t.Run("it will return 401 for web paths when enabled", func(t *testing.T) {
+		Config.BasicAuthEnabled = true
+		Config.BasicAuthUsername = "admin"
+		Config.BasicAuthPassword = "password"
+		defer func() {
+			Config.BasicAuthEnabled = false
+			Config.BasicAuthUsername = ""
+			Config.BasicAuthPassword = ""
+		}()
+
+		testPaths := []string{"/", "", "/#", "/#/", "/static", "/static/"}
+		for _, path := range testPaths {
+			t.Run(fmt.Sprintf("path: %s", path), func(t *testing.T) {
+				hh := SetupGlobalMiddleware(h)
+				res := httptest.NewRecorder()
+				res.Body = new(bytes.Buffer)
+				req, _ := http.NewRequest("GET", fmt.Sprintf("http://localhost:18000%s", path), nil)
+				hh.ServeHTTP(res, req)
+				assert.Equal(t, http.StatusUnauthorized, res.Code)
 			})
 		}
 	})


### PR DESCRIPTION
Add optional basic auth support to keep the interface from being publicly available.

## Description
- Added new environment variables to enable and configure basic authentication. Disabled by default.
- When enabled, adds a new middleware to support basic auth
- Respect whitelist of paths (prefix or exact match)

## Motivation and Context
- This solves the issue of hosting flagr where it is reachable on the public internet but you do not want outside users to access the web interface.

## How Has This Been Tested?
- Deployed to our hosting provider and manually tested basic auth prompt with various env values.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.