### PR TITLE
Strip eval context

### DIFF
--- a/docs/api_docs/bundle.yaml
+++ b/docs/api_docs/bundle.yaml
@@ -1197,6 +1197,9 @@ definitions:
         minItems: 1
       enableDebug:
         type: boolean
+      stripEvalContext:
+        type: boolean
+        default: false
       flagIDs:
         description: flagIDs
         type: array

--- a/pkg/config/env.go
+++ b/pkg/config/env.go
@@ -185,6 +185,9 @@ var Config = struct {
 	// "HS256" and "RS256" supported
 	JWTAuthSigningMethod string `env:"FLAGR_JWT_AUTH_SIGNING_METHOD" envDefault:"HS256"`
 
+	// Verify the JWT through OIDC flows
+	JWTAuthOIDCWellKnownURL string `env:"FLAGR_JWT_AUTH_OIDC_WELL_KNOWN_URL" envDefault:""`
+
 	// Identify users through headers
 	HeaderAuthEnabled   bool   `env:"FLAGR_HEADER_AUTH_ENABLED" envDefault:"false"`
 	HeaderAuthUserField string `env:"FLAGR_HEADER_AUTH_USER_FIELD" envDefault:"X-Email"`

--- a/pkg/config/middleware.go
+++ b/pkg/config/middleware.go
@@ -1,8 +1,16 @@
 package config
 
 import (
+	"bytes"
+	"crypto/rsa"
 	"crypto/subtle"
+	"encoding/base64"
+	"encoding/binary"
+	"encoding/json"
+	"errors"
 	"fmt"
+	"io/ioutil"
+	"math/big"
 	"net/http"
 	"strconv"
 	"strings"
@@ -120,6 +128,165 @@ func setupRecoveryMiddleware() *negroni.Recovery {
 	return r
 }
 
+type OidcConfiguation struct {
+	JwkURI string `json:"jwks_uri"` // This is the only field we care about for now.
+}
+
+type OidcJwk struct {
+	JWKeyID     string   `json:"kid"` // JWTs will have a "kid" that will match one of these
+	SigningKeys []string `json:"x5c"` // We prefer the x5c since it's easier
+	Exponent    string   `json:"e"`   // The least preferred way is recreating the key through exponent.
+	Modulus     string   `json:"n"`   // The modulus
+}
+
+type OidcJwksConfiguration struct {
+	Jwks []OidcJwk `json:"keys"`
+}
+
+func discoverOidcJwk(tokenKeyID string) *OidcJwk {
+	// First we need to access the well known url to find out what the jwk_uri is.
+	resp, err := http.Get(Config.JWTAuthOIDCWellKnownURL)
+	if err != nil {
+		logrus.Errorln("Failed to contact OIDC well known URL")
+		return nil
+	}
+
+	// Read in the oidc config information, and unmarshal it into our oidc config.
+	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		logrus.Errorln("Failed to read from OIDC well known URL")
+		return nil
+	}
+
+	var oidcConfig OidcConfiguation
+	json.Unmarshal([]byte(body), &oidcConfig)
+
+	if oidcConfig.JwkURI == "" {
+		logrus.Errorln("OIDC configuration didn't contain a valid jwks_uri")
+		return nil
+	}
+
+	// Now we need to read in the jwks info.
+	oidcJwksResp, err := http.Get(oidcConfig.JwkURI)
+	if err != nil {
+		logrus.Errorln("Failed to contact the JWK URI")
+		return nil
+	}
+
+	// Read in the jwks and unmarshall it.
+	defer oidcJwksResp.Body.Close()
+	body, err = ioutil.ReadAll(oidcJwksResp.Body)
+	if err != nil {
+		logrus.Errorln("Failed to read the JWKs body")
+		return nil
+	}
+
+	var oidcJwks OidcJwksConfiguration
+
+	json.Unmarshal([]byte(body), &oidcJwks)
+
+	// Find the key that matches the one in the JWT
+	if oidcJwks.Jwks == nil {
+		logrus.Errorln("Missing keys in the jwk config")
+		return nil
+	}
+
+	var numKeys = len(oidcJwks.Jwks)
+	if numKeys == 0 {
+		logrus.Errorln("No keys in the jwk config")
+		return nil
+	}
+
+	matchingKey := -1
+	for currentKey := 0; currentKey < numKeys; currentKey++ {
+		if oidcJwks.Jwks[currentKey].JWKeyID == tokenKeyID {
+			matchingKey = currentKey
+			break
+		}
+	}
+
+	if matchingKey == -1 {
+		logrus.Errorln("No matching key found in the jwk config")
+		return nil
+	}
+
+	return &oidcJwks.Jwks[matchingKey]
+}
+
+func extractJWTSigningKeyFromX5C(oidcJwk *OidcJwk) (interface{}, error) {
+	correctKey := oidcJwk.SigningKeys[0]
+
+	// Now we will take the first key and convert it into a cert
+	// that the library we user are familiar with. This cert requires
+	// a very specific format that is dependent on whitespace :/
+	// There can only be 64 characters on a line or else it won't read it
+	// so we have to do that manually. Also the BEGIN and END lines need to
+	// be their own lines.
+	numCharsInKey := len(correctKey)
+	var numLines int = numCharsInKey / 64
+	if numLines%64 > 0 {
+		numLines++
+	}
+
+	var jwtCert string = "-----BEGIN PUBLIC KEY-----\n"
+	for currentLine := 0; currentLine < numLines; currentLine++ {
+		startCharacter := currentLine * 64
+		endCharacter := startCharacter + 64
+		if startCharacter+64 > numCharsInKey {
+			endCharacter = numCharsInKey
+		}
+
+		jwtCert += correctKey[startCharacter:endCharacter] + "\n"
+	}
+	jwtCert += "-----END PUBLIC KEY-----"
+
+	return jwt.ParseRSAPublicKeyFromPEM([]byte(jwtCert))
+}
+
+func calculateJWTSigningKey(jwk *OidcJwk) (interface{}, error) {
+	if jwk.Modulus == "" || jwk.Exponent == "" {
+		return "", errors.New("Invalid Modulus or Exponent provided")
+	}
+
+	// Decode the modulus and move it into a big int.
+	logrus.Printf("Modulus found: " + jwk.Modulus)
+	decN, err := base64.RawURLEncoding.DecodeString(jwk.Modulus)
+	if err != nil {
+		logrus.Errorf("Failed to decode modulus string.")
+		return "", err
+	}
+	n := big.NewInt(0)
+	n.SetBytes(decN)
+
+	// Decode the exponent
+	logrus.Printf("Exponent found: " + jwk.Exponent)
+	eStr := jwk.Exponent
+	decE, err := base64.RawURLEncoding.DecodeString(eStr)
+	if err != nil {
+		logrus.Errorf("Failed to decode exponent string")
+		return "", err
+	}
+
+	var eBytes []byte
+	if len(decE) < 8 {
+		eBytes = make([]byte, 8-len(decE), 8)
+		eBytes = append(eBytes, decE...)
+	} else {
+		eBytes = decE
+	}
+	eReader := bytes.NewReader(eBytes)
+	var e uint64
+	err = binary.Read(eReader, binary.BigEndian, &e)
+	if err != nil {
+		logrus.Errorf("Failed to read exponent bytes")
+		return "", err
+	}
+	pKey := &rsa.PublicKey{N: n, E: int(e)}
+	logrus.Printf("Created public key.")
+	return pKey, nil
+}
+
 /**
 setupJWTAuthMiddleware setup an JWTMiddleware from the ENV config
 */
@@ -143,14 +310,40 @@ func setupJWTAuthMiddleware() *jwtAuth {
 		validationKey = []byte("")
 	}
 
+	var validationKeyGetter = func(token *jwt.Token) (interface{}, error) {
+		return validationKey, errParsingKey
+	}
+
+	if Config.JWTAuthOIDCWellKnownURL != "" {
+		validationKeyGetter = func(token *jwt.Token) (interface{}, error) {
+
+			// If this is truly an OIDC token, it should have a "kid" header in the token.
+			var tokenKeyID = token.Header["kid"]
+			if tokenKeyID == nil {
+				return "", errors.New("Missing key id in the JWT")
+			}
+
+			var jwk = discoverOidcJwk(tokenKeyID.(string))
+			if jwk == nil {
+				return "", errors.New("Failed to find JWK for JWT")
+			}
+
+			if len(jwk.SigningKeys) > 0 {
+				return extractJWTSigningKeyFromX5C(jwk)
+			} else if jwk.Exponent != "" && jwk.Modulus != "" {
+				return calculateJWTSigningKey(jwk)
+			} else {
+				return "", errors.New("JWK is invalid")
+			}
+		}
+	}
+
 	return &jwtAuth{
 		PrefixWhitelistPaths: Config.JWTAuthPrefixWhitelistPaths,
 		ExactWhitelistPaths:  Config.JWTAuthExactWhitelistPaths,
 		JWTMiddleware: jwtmiddleware.New(jwtmiddleware.Options{
-			ValidationKeyGetter: func(token *jwt.Token) (interface{}, error) {
-				return validationKey, errParsingKey
-			},
-			SigningMethod: signingMethod,
+			ValidationKeyGetter: validationKeyGetter,
+			SigningMethod:       signingMethod,
 			Extractor: jwtmiddleware.FromFirst(
 				func(r *http.Request) (string, error) {
 					c, err := r.Cookie(Config.JWTAuthCookieTokenName)

--- a/pkg/handler/eval_test.go
+++ b/pkg/handler/eval_test.go
@@ -146,7 +146,7 @@ func TestEvalFlag(t *testing.T) {
 
 	t.Run("test empty evalContext", func(t *testing.T) {
 		defer gostub.StubFunc(&GetEvalCache, GenFixtureEvalCache()).Reset()
-		result := EvalFlag(models.EvalContext{FlagID: int64(100)})
+		result := EvalFlag(models.EvalContext{FlagID: int64(100)}, false)
 		assert.Zero(t, result.VariantID)
 		assert.NotZero(t, result.FlagID)
 		assert.NotEmpty(t, result.EvalContext.EntityID)
@@ -160,7 +160,7 @@ func TestEvalFlag(t *testing.T) {
 			EntityID:      "entityID1",
 			EntityType:    "entityType1",
 			FlagID:        int64(100),
-		})
+		}, false)
 		assert.NotNil(t, result)
 		assert.NotNil(t, result.VariantID)
 	})
@@ -173,7 +173,7 @@ func TestEvalFlag(t *testing.T) {
 			EntityID:      "entityID1",
 			EntityType:    "entityType1",
 			FlagKey:       "flag_key_100",
-		})
+		}, false)
 		assert.NotNil(t, result)
 		assert.NotNil(t, result.VariantID)
 	})
@@ -186,7 +186,7 @@ func TestEvalFlag(t *testing.T) {
 			EntityID:      "entityID1",
 			EntityType:    "entityType1",
 			FlagKey:       "flag_key_100",
-		})
+		}, false)
 		assert.NotNil(t, result)
 		assert.NotNil(t, result.VariantID)
 	})
@@ -225,7 +225,7 @@ func TestEvalFlag(t *testing.T) {
 			EntityID:      "entityID1",
 			EntityType:    "entityType1",
 			FlagID:        int64(100),
-		})
+		}, false)
 		assert.NotNil(t, result)
 		assert.NotNil(t, result.VariantID)
 	})
@@ -245,7 +245,7 @@ func TestEvalFlag(t *testing.T) {
 			EntityID:      "entityID1",
 			EntityType:    "entityType1",
 			FlagID:        int64(100),
-		})
+		}, false)
 		assert.NotNil(t, result)
 		assert.Zero(t, result.VariantID)
 	})
@@ -277,7 +277,7 @@ func TestEvalFlag(t *testing.T) {
 			EntityID:      "entityID1",
 			EntityType:    "entityType1",
 			FlagID:        int64(100),
-		})
+		}, false)
 		assert.NotNil(t, result)
 		assert.Zero(t, result.VariantID)
 	})
@@ -293,7 +293,7 @@ func TestEvalFlag(t *testing.T) {
 			EntityID:      "entityID1",
 			EntityType:    "entityType1",
 			FlagID:        int64(100),
-		})
+		}, false)
 		assert.NotNil(t, result)
 		assert.Zero(t, result.VariantID)
 	})
@@ -310,7 +310,7 @@ func TestEvalFlag(t *testing.T) {
 				EntityID:      "entityID1",
 				EntityType:    "entityType1",
 				FlagID:        int64(100),
-			})
+			}, false)
 			assert.NotNil(t, result)
 			assert.NotNil(t, result.VariantID)
 			assert.Equal(t, "entityType1", result.EvalContext.EntityType)
@@ -326,7 +326,7 @@ func TestEvalFlag(t *testing.T) {
 				EntityID:      "entityID1",
 				EntityType:    "entityType1",
 				FlagID:        int64(100),
-			})
+			}, false)
 			assert.NotNil(t, result)
 			assert.NotNil(t, result.VariantID)
 			assert.NotEqual(t, "entityType1", result.EvalContext.EntityType)

--- a/swagger/index.yaml
+++ b/swagger/index.yaml
@@ -485,6 +485,9 @@ definitions:
         minItems: 1
       enableDebug:
         type: boolean
+      stripEvalContext:
+        type: boolean
+        default: false
       flagIDs:
         description: flagIDs
         type: array

--- a/swagger_gen/models/evaluation_batch_request.go
+++ b/swagger_gen/models/evaluation_batch_request.go
@@ -34,6 +34,9 @@ type EvaluationBatchRequest struct {
 	// flagKeys. Either flagIDs or flagKeys works. If pass in both, Flagr may return duplicate results.
 	// Min Items: 1
 	FlagKeys []string `json:"flagKeys"`
+
+	// strip eval context
+	StripEvalContext *bool `json:"stripEvalContext,omitempty"`
 }
 
 // Validate validates this evaluation batch request

--- a/swagger_gen/restapi/embedded_spec.go
+++ b/swagger_gen/restapi/embedded_spec.go
@@ -1424,6 +1424,10 @@ func init() {
             "type": "string",
             "minLength": 1
           }
+        },
+        "stripEvalContext": {
+          "type": "boolean",
+          "default": false
         }
       }
     },
@@ -3203,6 +3207,10 @@ func init() {
             "type": "string",
             "minLength": 1
           }
+        },
+        "stripEvalContext": {
+          "type": "boolean",
+          "default": false
         }
       }
     },


### PR DESCRIPTION
Removing Eval Context from Batch Evaluation Responses.

## Description
Providing an optional parameter on the batch evaluation request to remove the eval context from the response. This context was already provided by the client when making the request, and returning it doesn't seem necessary, and more importantly, drastically increases the size of the response when providing any sufficiently large context. It especially is difficult when evaluating a large amount of flags or entities, since the context is returned for each flag and for each entity, further exacerbating the issue. 

## Motivation and Context
Reducing the size of the response when performing a batch evaluation. 

## How Has This Been Tested?
Verified in builds, no unit tests were added.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ x ] My code follows the code style of this project.
- [ x ] My change requires a change to the documentation.
- [ x ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ x ] All new and existing tests passed.