### PR TITLE
Add exclude_snapshots query param to export/sqlite

### DIFF
--- a/docs/api_docs/bundle.yaml
+++ b/docs/api_docs/bundle.yaml
@@ -771,6 +771,13 @@ paths:
       tags:
         - export
       operationId: getExportSqlite
+      parameters:
+        - in: query
+          name: exclude_snapshots
+          type: boolean
+          description: >
+            export without snapshots data - useful for smaller db without
+            snapshots
       description: >-
         Export sqlite3 format of the db dump, which is converted from the main
         database.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/checkr/flagr
 
-go 1.12
+go 1.14
 
 require (
 	cloud.google.com/go v0.37.4

--- a/pkg/handler/export_test.go
+++ b/pkg/handler/export_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/checkr/flagr/pkg/entity"
+	"github.com/checkr/flagr/pkg/util"
 	"github.com/checkr/flagr/swagger_gen/restapi/operations/export"
 	"github.com/prashantv/gostub"
 	"github.com/stretchr/testify/assert"
@@ -63,8 +64,16 @@ func TestExportSQLiteFile(t *testing.T) {
 	defer db.Close()
 	defer gostub.StubFunc(&getDB, db).Reset()
 
-	t.Run("happy code path", func(t *testing.T) {
-		f, done, err := exportSQLiteFile()
+	t.Run("happy code path and export everything in db", func(t *testing.T) {
+		f, done, err := exportSQLiteFile(nil)
+		defer done()
+
+		assert.NoError(t, err)
+		assert.NotNil(t, f)
+	})
+
+	t.Run("happy code path and exclude_snapshots", func(t *testing.T) {
+		f, done, err := exportSQLiteFile(util.BoolPtr(true))
 		defer done()
 
 		assert.NoError(t, err)

--- a/swagger/export_sqlite.yaml
+++ b/swagger/export_sqlite.yaml
@@ -2,6 +2,12 @@ get:
   tags:
     - export
   operationId: getExportSqlite
+  parameters:
+    - in: query
+      name: exclude_snapshots
+      type: boolean
+      description: >
+        export without snapshots data - useful for smaller db without snapshots
   description: Export sqlite3 format of the db dump, which is converted from the main database.
   produces:
     - application/octet-stream

--- a/swagger_gen/restapi/embedded_spec.go
+++ b/swagger_gen/restapi/embedded_spec.go
@@ -137,6 +137,14 @@ func init() {
           "export"
         ],
         "operationId": "getExportSqlite",
+        "parameters": [
+          {
+            "type": "boolean",
+            "description": "export without snapshots data - useful for smaller db without snapshots\n",
+            "name": "exclude_snapshots",
+            "in": "query"
+          }
+        ],
         "responses": {
           "200": {
             "description": "OK",
@@ -1914,6 +1922,14 @@ func init() {
           "export"
         ],
         "operationId": "getExportSqlite",
+        "parameters": [
+          {
+            "type": "boolean",
+            "description": "export without snapshots data - useful for smaller db without snapshots\n",
+            "name": "exclude_snapshots",
+            "in": "query"
+          }
+        ],
         "responses": {
           "200": {
             "description": "OK",

--- a/swagger_gen/restapi/operations/export/get_export_sqlite_urlbuilder.go
+++ b/swagger_gen/restapi/operations/export/get_export_sqlite_urlbuilder.go
@@ -9,11 +9,17 @@ import (
 	"errors"
 	"net/url"
 	golangswaggerpaths "path"
+
+	"github.com/go-openapi/swag"
 )
 
 // GetExportSqliteURL generates an URL for the get export sqlite operation
 type GetExportSqliteURL struct {
+	ExcludeSnapshots *bool
+
 	_basePath string
+	// avoid unkeyed usage
+	_ struct{}
 }
 
 // WithBasePath sets the base path for this url builder, only required when it's different from the
@@ -42,6 +48,18 @@ func (o *GetExportSqliteURL) Build() (*url.URL, error) {
 		_basePath = "/api/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
+
+	qs := make(url.Values)
+
+	var excludeSnapshotsQ string
+	if o.ExcludeSnapshots != nil {
+		excludeSnapshotsQ = swag.FormatBool(*o.ExcludeSnapshots)
+	}
+	if excludeSnapshotsQ != "" {
+		qs.Set("exclude_snapshots", excludeSnapshotsQ)
+	}
+
+	_result.RawQuery = qs.Encode()
 
 	return &_result, nil
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,4 +1,5 @@
 # cloud.google.com/go v0.37.4
+## explicit
 cloud.google.com/go/compute/metadata
 cloud.google.com/go/iam
 cloud.google.com/go/internal/optional
@@ -9,22 +10,31 @@ cloud.google.com/go/pubsub/apiv1
 cloud.google.com/go/pubsub/internal/distribution
 cloud.google.com/go/pubsub/pstest
 # github.com/DataDog/datadog-go v0.0.0-20180330214955-e67964b4021a
+## explicit
 github.com/DataDog/datadog-go/statsd
 # github.com/PuerkitoBio/purell v1.1.0
+## explicit
 github.com/PuerkitoBio/purell
 # github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578
+## explicit
 github.com/PuerkitoBio/urlesc
 # github.com/Shopify/sarama v1.19.0
+## explicit
 github.com/Shopify/sarama
 # github.com/a8m/kinesis-producer v0.0.0-20180723062609-03228a9f79b3
+## explicit
 github.com/a8m/kinesis-producer
 # github.com/asaskevich/govalidator v0.0.0-20180315120708-ccb8e960c48f
+## explicit
 github.com/asaskevich/govalidator
 # github.com/auth0/go-jwt-middleware v0.0.0-20170425171159-5493cabe49f7
+## explicit
 github.com/auth0/go-jwt-middleware
 # github.com/avast/retry-go v2.2.0+incompatible
+## explicit
 github.com/avast/retry-go
 # github.com/aws/aws-sdk-go v1.15.32
+## explicit
 github.com/aws/aws-sdk-go/aws
 github.com/aws/aws-sdk-go/aws/awserr
 github.com/aws/aws-sdk-go/aws/awsutil
@@ -58,20 +68,32 @@ github.com/aws/aws-sdk-go/service/sts
 # github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973
 github.com/beorn7/perks/quantile
 # github.com/brandur/simplebox v0.0.0-20150921201729-84e9865bb03a
+## explicit
 github.com/brandur/simplebox
 # github.com/bsm/ratelimit v2.0.0+incompatible
+## explicit
 github.com/bsm/ratelimit
 # github.com/caarlos0/env v3.3.0+incompatible
+## explicit
 github.com/caarlos0/env
 # github.com/certifi/gocertifi v0.0.0-20180118203423-deb3ae2ef261
+## explicit
 github.com/certifi/gocertifi
+# github.com/codegangsta/negroni v1.0.0
+## explicit
 # github.com/davecgh/go-spew v1.1.1
+## explicit
 github.com/davecgh/go-spew/spew
 # github.com/dchest/uniuri v0.0.0-20160212164326-8902c56451e9
+## explicit
 github.com/dchest/uniuri
+# github.com/denisenkom/go-mssqldb v0.0.0-20190418034912-35416408c946
+## explicit
 # github.com/dgrijalva/jwt-go v3.2.0+incompatible
+## explicit
 github.com/dgrijalva/jwt-go
 # github.com/docker/go-units v0.3.3
+## explicit
 github.com/docker/go-units
 # github.com/eapache/go-resiliency v1.1.0
 github.com/eapache/go-resiliency/breaker
@@ -79,27 +101,39 @@ github.com/eapache/go-resiliency/breaker
 github.com/eapache/go-xerial-snappy
 # github.com/eapache/queue v1.1.0
 github.com/eapache/queue
+# github.com/erikstmartin/go-testdb v0.0.0-20160219214506-8d10e4a1bae5
+## explicit
 # github.com/evalphobia/logrus_sentry v0.4.6
+## explicit
 github.com/evalphobia/logrus_sentry
 # github.com/getsentry/raven-go v0.0.0-20180903072508-084a9de9eb03
+## explicit
 github.com/getsentry/raven-go
 # github.com/globalsign/mgo v0.0.0-20180905125535-1ca0a4f7cbcb
+## explicit
 github.com/globalsign/mgo/bson
 github.com/globalsign/mgo/internal/json
 # github.com/go-ini/ini v1.38.2
+## explicit
 github.com/go-ini/ini
 # github.com/go-openapi/analysis v0.0.0-20180801175213-7c1bef8f6d9f
+## explicit
 github.com/go-openapi/analysis
 github.com/go-openapi/analysis/internal
 # github.com/go-openapi/errors v0.0.0-20180827163446-87bb65328877
+## explicit
 github.com/go-openapi/errors
 # github.com/go-openapi/jsonpointer v0.0.0-20180322222829-3a0015ad55fa
+## explicit
 github.com/go-openapi/jsonpointer
 # github.com/go-openapi/jsonreference v0.0.0-20180322222742-3fb327e6747d
+## explicit
 github.com/go-openapi/jsonreference
 # github.com/go-openapi/loads v0.0.0-20180825180312-fd899182a268
+## explicit
 github.com/go-openapi/loads
 # github.com/go-openapi/runtime v0.0.0-20180910204625-41cb9a631c39
+## explicit
 github.com/go-openapi/runtime
 github.com/go-openapi/runtime/flagext
 github.com/go-openapi/runtime/logger
@@ -109,16 +143,22 @@ github.com/go-openapi/runtime/middleware/header
 github.com/go-openapi/runtime/middleware/untyped
 github.com/go-openapi/runtime/security
 # github.com/go-openapi/spec v0.0.0-20180825180323-f1468acb3b29
+## explicit
 github.com/go-openapi/spec
 # github.com/go-openapi/strfmt v0.0.0-20180910212104-776114108ccc
+## explicit
 github.com/go-openapi/strfmt
 # github.com/go-openapi/swag v0.0.0-20180908172849-dd0dad036e67
+## explicit
 github.com/go-openapi/swag
 # github.com/go-openapi/validate v0.0.0-20180825180342-e0648ff40507
+## explicit
 github.com/go-openapi/validate
 # github.com/go-sql-driver/mysql v1.4.0
+## explicit
 github.com/go-sql-driver/mysql
 # github.com/gohttp/pprof v0.0.0-20141119085724-c9d246cbb3ba
+## explicit
 github.com/gohttp/pprof
 # github.com/golang/protobuf v1.2.0
 github.com/golang/protobuf/proto
@@ -137,40 +177,56 @@ github.com/google/go-cmp/cmp/internal/function
 github.com/google/go-cmp/cmp/internal/value
 # github.com/googleapis/gax-go/v2 v2.0.4
 github.com/googleapis/gax-go/v2
+# github.com/gorilla/mux v1.7.1
+## explicit
 # github.com/hashicorp/golang-lru v0.5.0
 github.com/hashicorp/golang-lru/simplelru
 # github.com/jessevdk/go-flags v1.4.0
+## explicit
 github.com/jessevdk/go-flags
 # github.com/jinzhu/gorm v0.0.0-20180909231100-123d4f50ef8a
+## explicit
 github.com/jinzhu/gorm
 github.com/jinzhu/gorm/dialects/mysql
 github.com/jinzhu/gorm/dialects/postgres
 github.com/jinzhu/gorm/dialects/sqlite
 # github.com/jinzhu/inflection v0.0.0-20180308033659-04140366298a
+## explicit
 github.com/jinzhu/inflection
+# github.com/jinzhu/now v1.0.0
+## explicit
 # github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8
 github.com/jmespath/go-jmespath
 # github.com/jpillora/backoff v0.0.0-20170918002102-8eab2debe79d
+## explicit
 github.com/jpillora/backoff
 # github.com/konsorten/go-windows-terminal-sequences v1.0.1
 github.com/konsorten/go-windows-terminal-sequences
+# github.com/kr/pretty v0.1.0
+## explicit
 # github.com/lib/pq v1.0.0
+## explicit
 github.com/lib/pq
 github.com/lib/pq/hstore
 github.com/lib/pq/oid
 # github.com/mailru/easyjson v0.0.0-20180823135443-60711f1a8329
+## explicit
 github.com/mailru/easyjson/buffer
 github.com/mailru/easyjson/jlexer
 github.com/mailru/easyjson/jwriter
 # github.com/mattn/go-sqlite3 v1.9.0
+## explicit
 github.com/mattn/go-sqlite3
 # github.com/matttproud/golang_protobuf_extensions v1.0.1
 github.com/matttproud/golang_protobuf_extensions/pbutil
 # github.com/meatballhat/negroni-logrus v0.0.0-20170801195057-31067281800f
+## explicit
 github.com/meatballhat/negroni-logrus
 # github.com/mitchellh/mapstructure v1.1.2
+## explicit
 github.com/mitchellh/mapstructure
 # github.com/newrelic/go-agent v2.1.0+incompatible
+## explicit
 github.com/newrelic/go-agent
 github.com/newrelic/go-agent/internal
 github.com/newrelic/go-agent/internal/cat
@@ -178,9 +234,19 @@ github.com/newrelic/go-agent/internal/jsonx
 github.com/newrelic/go-agent/internal/logger
 github.com/newrelic/go-agent/internal/sysinfo
 github.com/newrelic/go-agent/internal/utilization
+# github.com/onsi/ginkgo v1.8.0
+## explicit
+# github.com/onsi/gomega v1.5.0
+## explicit
+# github.com/opentracing/opentracing-go v1.1.0
+## explicit
+# github.com/pborman/uuid v1.2.0
+## explicit
 # github.com/philhofer/fwd v1.0.0
+## explicit
 github.com/philhofer/fwd
 # github.com/phyber/negroni-gzip v0.0.0-20180113114010-ef6356a5d029
+## explicit
 github.com/phyber/negroni-gzip/gzip
 # github.com/pierrec/lz4 v2.0.5+incompatible
 github.com/pierrec/lz4
@@ -190,19 +256,23 @@ github.com/pkg/errors
 # github.com/pmezard/go-difflib v1.0.0
 github.com/pmezard/go-difflib/difflib
 # github.com/prashantv/gostub v0.0.0-20170112001514-5c68b99bb088
+## explicit
 github.com/prashantv/gostub
 # github.com/prometheus/client_golang v0.9.3-0.20190127221311-3c4408c8b829
+## explicit
 github.com/prometheus/client_golang/prometheus
 github.com/prometheus/client_golang/prometheus/internal
 github.com/prometheus/client_golang/prometheus/promauto
 github.com/prometheus/client_golang/prometheus/promhttp
 # github.com/prometheus/client_model v0.0.0-20190129233127-fd36f4220a90
+## explicit
 github.com/prometheus/client_model/go
 # github.com/prometheus/common v0.2.0
 github.com/prometheus/common/expfmt
 github.com/prometheus/common/internal/bitbucket.org/ww/goautoneg
 github.com/prometheus/common/model
 # github.com/prometheus/procfs v0.0.0-20190219184716-e4d4a2206da0
+## explicit
 github.com/prometheus/procfs
 github.com/prometheus/procfs/internal/util
 github.com/prometheus/procfs/iostats
@@ -211,22 +281,33 @@ github.com/prometheus/procfs/xfs
 # github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a
 github.com/rcrowley/go-metrics
 # github.com/rs/cors v1.5.0
+## explicit
 github.com/rs/cors
 # github.com/sirupsen/logrus v1.2.0
+## explicit
 github.com/sirupsen/logrus
+# github.com/smartystreets/goconvey v0.0.0-20190330032615-68dc04aab96a
+## explicit
 # github.com/spf13/cast v1.3.0
+## explicit
 github.com/spf13/cast
 # github.com/stretchr/testify v1.3.0
+## explicit
 github.com/stretchr/testify/assert
 # github.com/tinylib/msgp v1.1.0
+## explicit
 github.com/tinylib/msgp/msgp
 # github.com/urfave/negroni v0.3.0
+## explicit
 github.com/urfave/negroni
 # github.com/yadvendar/negroni-newrelic-go-agent v0.0.0-20160803090806-3dc58758cb67
+## explicit
 github.com/yadvendar/negroni-newrelic-go-agent
 # github.com/zhouzhuojie/conditions v0.0.0-20190705160302-784df330cb87
+## explicit
 github.com/zhouzhuojie/conditions
 # github.com/zhouzhuojie/withtimeout v0.0.0-20190405051827-12b39eb2edd5
+## explicit
 github.com/zhouzhuojie/withtimeout
 # go.opencensus.io v0.20.1
 go.opencensus.io
@@ -253,6 +334,7 @@ golang.org/x/crypto/poly1305
 golang.org/x/crypto/salsa20/salsa
 golang.org/x/crypto/ssh/terminal
 # golang.org/x/net v0.0.0-20190313220215-9f648a60d977
+## explicit
 golang.org/x/net/context
 golang.org/x/net/context/ctxhttp
 golang.org/x/net/http/httpguts
@@ -272,6 +354,7 @@ golang.org/x/oauth2/jwt
 golang.org/x/sync/errgroup
 golang.org/x/sync/semaphore
 # golang.org/x/sys v0.0.0-20190312061237-fead79001313
+## explicit
 golang.org/x/sys/cpu
 golang.org/x/sys/unix
 golang.org/x/sys/windows
@@ -282,6 +365,7 @@ golang.org/x/text/unicode/bidi
 golang.org/x/text/unicode/norm
 golang.org/x/text/width
 # google.golang.org/api v0.3.1
+## explicit
 google.golang.org/api/googleapi/transport
 google.golang.org/api/internal
 google.golang.org/api/iterator
@@ -312,6 +396,7 @@ google.golang.org/genproto/googleapis/pubsub/v1
 google.golang.org/genproto/googleapis/rpc/status
 google.golang.org/genproto/protobuf/field_mask
 # google.golang.org/grpc v1.19.0
+## explicit
 google.golang.org/grpc
 google.golang.org/grpc/balancer
 google.golang.org/grpc/balancer/base
@@ -345,9 +430,12 @@ google.golang.org/grpc/stats
 google.golang.org/grpc/status
 google.golang.org/grpc/tap
 # gopkg.in/DataDog/dd-trace-go.v1 v1.9.0
+## explicit
 gopkg.in/DataDog/dd-trace-go.v1/ddtrace
 gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext
 gopkg.in/DataDog/dd-trace-go.v1/ddtrace/internal
 gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer
+# gopkg.in/ini.v1 v1.42.0
+## explicit
 # gopkg.in/yaml.v2 v2.2.2
 gopkg.in/yaml.v2


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Sometimes the snapshots table is just too big to download, wanted to introduce a query param that can help to reduce the sqlite export size. This is fully backward compatible.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
unit tests and integration test

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.