### PR TITLE
Config option to exclude URLs from verbose middleware logging

### DIFF
--- a/pkg/config/env.go
+++ b/pkg/config/env.go
@@ -19,6 +19,8 @@ var Config = struct {
 
 	// MiddlewareVerboseLoggerEnabled - to enable the negroni-logrus logger for all the endpoints useful for debugging
 	MiddlewareVerboseLoggerEnabled bool `env:"FLAGR_MIDDLEWARE_VERBOSE_LOGGER_ENABLED" envDefault:"true"`
+	// MiddlewareVerboseLoggerExcludeURLs - to exclude urls from the verbose logger via comma separated list
+	MiddlewareVerboseLoggerExcludeURLs []string `env:"FLAGR_MIDDLEWARE_VERBOSE_LOGGER_EXCLUDE_URLS" envDefault:"" envSeparator:","`
 	// MiddlewareGzipEnabled - to enable gzip middleware
 	MiddlewareGzipEnabled bool `env:"FLAGR_MIDDLEWARE_GZIP_ENABLED" envDefault:"true"`
 

--- a/pkg/config/middleware.go
+++ b/pkg/config/middleware.go
@@ -39,7 +39,13 @@ func SetupGlobalMiddleware(handler http.Handler) http.Handler {
 	}
 
 	if Config.MiddlewareVerboseLoggerEnabled {
-		n.Use(negronilogrus.NewMiddlewareFromLogger(logrus.StandardLogger(), "flagr"))
+		middleware := negronilogrus.NewMiddlewareFromLogger(logrus.StandardLogger(), "flagr")
+
+		for _, u := range Config.MiddlewareVerboseLoggerExcludeURLs {
+			middleware.ExcludeURL(u)
+		}
+
+		n.Use(middleware)
 	}
 
 	if Config.StatsdEnabled {


### PR DESCRIPTION
Add configurable option to exclude URLs from verbose middleware logging

## Description

We added `MiddlewareVerboseLoggerExcludeURLs`  env where excluded urls can be specified as a list of string comma separated. We configure the middleware logging with this configuration setting.

## Motivation and Context

Currently we have integrated Flagr on our infrastructure and we wanted to remove logging entries for not relevant urls like health check or metrics. So we can focus on relevant ones.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.