### PR TITLE
Remove margin on compact class

### DIFF
--- a/browser/flagr-ui/src/components/FlagHistory.vue
+++ b/browser/flagr-ui/src/components/FlagHistory.vue
@@ -87,9 +87,6 @@ export default {
 
 <style lang="less">
 .snapshot-container {
-  .compact {
-    margin: -8px 0px;
-  }
   .diff-snapshot-id-change {
     color: white;
     .el-tag {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Remove margin on `.compact` class to add more space between timestamp and updated by section 

## Description
Before
<img width="1663" alt="Screen Shot 2020-09-10 at 16 29 39" src="https://user-images.githubusercontent.com/1484384/92712113-6ccf1f00-f383-11ea-84c0-1a2e9d865c15.png">

After removing margin
<img width="1673" alt="Screen Shot 2020-09-10 at 16 29 53" src="https://user-images.githubusercontent.com/1484384/92712153-7c4e6800-f383-11ea-9329-ec1f70dd3819.png">


## Motivation and Context
I've setup Flagr using HTTP Header auth, when I saw the Flag history page, I noticed that the gap between snapshot's timestamp and updated by is too narrow. Removing margin seems solve this issue. Also this removal won't affect snapshot without updated by section as it's using different CSS class

## How Has This Been Tested?
Tested on local using these browsers : 
- Google Chrome Version 85.0.4183.83 (Official Build) (64-bit)
- Firefox 80.0.1 (64-bit)
- Safari Version 13.1.2 (15609.3.5.1.3)

## Types of changes
UI change
