### PR TITLE
Refactor eval cache with atomic.Value

### DIFF
--- a/pkg/handler/eval_cache_fetcher.go
+++ b/pkg/handler/eval_cache_fetcher.go
@@ -18,19 +18,16 @@ type EvalCacheJSON struct {
 }
 
 func (ec *EvalCache) export() EvalCacheJSON {
-	fs := make([]entity.Flag, 0, len(ec.idCache))
-
-	ec.mapCacheLock.RLock()
-	defer ec.mapCacheLock.RUnlock()
-
-	for _, f := range ec.idCache {
+	idCache := ec.cache.Load().(*cacheContainer).idCache
+	fs := make([]entity.Flag, 0, len(idCache))
+	for _, f := range idCache {
 		ff := *f
 		fs = append(fs, ff)
 	}
 	return EvalCacheJSON{Flags: fs}
 }
 
-func (ec *EvalCache) fetchAllFlags() (idCache mapCache, keyCache mapCache, tagCache multiMapCache, err error) {
+func (ec *EvalCache) fetchAllFlags() (idCache map[string]*entity.Flag, keyCache map[string]*entity.Flag, tagCache map[string]map[uint]*entity.Flag, err error) {
 	fs, err := fetchAllFlags()
 	if err != nil {
 		return nil, nil, nil, err

--- a/pkg/handler/fixture.go
+++ b/pkg/handler/fixture.go
@@ -14,9 +14,12 @@ func GenFixtureEvalCache() *EvalCache {
 		tagCache[tag.Value] = map[uint]*entity.Flag{f.ID: &f}
 	}
 
-	return &EvalCache{
+	ec := &EvalCache{}
+	ec.cache.Store(&cacheContainer{
 		idCache:  map[string]*entity.Flag{util.SafeString(f.ID): &f},
 		keyCache: map[string]*entity.Flag{f.Key: &f},
 		tagCache: tagCache,
-	}
+	})
+
+	return ec
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Fix https://github.com/checkr/flagr/issues/398
- Refactor all the cache with atomic.Value for concurrent access and reduce lock contention
- Refactor ratelimiter to sync.Map to reduce the rare chance of race condition
- Fix the logic of merging tags in `GetByTags` so that we are just merging into the temp variable instead of changing the protected cache



## How Has This Been Tested?
- unit tests
- integration tests
- manual tests
- benchmark



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.