### PR TITLE
Bump to go1.15

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ version: 2
 jobs:
   unit_test:
     docker:
-      - image: golang:1.14
+      - image: golang:1.15
     working_directory: /go/src/github.com/checkr/flagr
     steps:
       - checkout

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN make build_ui
 ######################################
 # Prepare go_builder
 ######################################
-FROM golang:1.14 as go_builder
+FROM golang:1.15 as go_builder
 WORKDIR /go/src/github.com/checkr/flagr
 ADD . .
 RUN make build

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/checkr/flagr
 
-go 1.14
+go 1.15
 
 require (
 	cloud.google.com/go v0.37.4

--- a/integration_tests/Dockerfile-Integration-Test
+++ b/integration_tests/Dockerfile-Integration-Test
@@ -1,7 +1,7 @@
 ######################################
 # Prepare go_builder
 ######################################
-FROM golang:1.14 as go_builder
+FROM golang:1.15 as go_builder
 WORKDIR /go/src/github.com/checkr/flagr
 ADD . .
 RUN make build


### PR DESCRIPTION
Keep up with the latest go version. It slightly reduces the binary size.