### PR TITLE
Add support for kafka auth using SASL with PLAIN mechanism

### DIFF
--- a/pkg/config/env.go
+++ b/pkg/config/env.go
@@ -134,6 +134,9 @@ var Config = struct {
 	RecorderKafkaKeyFile        string        `env:"FLAGR_RECORDER_KAFKA_KEYFILE" envDefault:""`
 	RecorderKafkaCAFile         string        `env:"FLAGR_RECORDER_KAFKA_CAFILE" envDefault:""`
 	RecorderKafkaVerifySSL      bool          `env:"FLAGR_RECORDER_KAFKA_VERIFYSSL" envDefault:"false"`
+	RecorderKafkaSimpleSSL      bool          `env:"FLAGR_RECORDER_KAFKA_SIMPLE_SSL" envDefault:"false"`
+	RecorderKafkaUsername       string        `env:"FLAGR_RECORDER_KAFKA_USERNAME" envDefault:""`
+	RecorderKafkaPassword       string        `env:"FLAGR_RECORDER_KAFKA_PASSWORD" envDefault:""`
 	RecorderKafkaVerbose        bool          `env:"FLAGR_RECORDER_KAFKA_VERBOSE" envDefault:"true"`
 	RecorderKafkaTopic          string        `env:"FLAGR_RECORDER_KAFKA_TOPIC" envDefault:"flagr-records"`
 	RecorderKafkaRetryMax       int           `env:"FLAGR_RECORDER_KAFKA_RETRYMAX" envDefault:"5"`

--- a/pkg/config/env.go
+++ b/pkg/config/env.go
@@ -135,8 +135,8 @@ var Config = struct {
 	RecorderKafkaCAFile         string        `env:"FLAGR_RECORDER_KAFKA_CAFILE" envDefault:""`
 	RecorderKafkaVerifySSL      bool          `env:"FLAGR_RECORDER_KAFKA_VERIFYSSL" envDefault:"false"`
 	RecorderKafkaSimpleSSL      bool          `env:"FLAGR_RECORDER_KAFKA_SIMPLE_SSL" envDefault:"false"`
-	RecorderKafkaUsername       string        `env:"FLAGR_RECORDER_KAFKA_USERNAME" envDefault:""`
-	RecorderKafkaPassword       string        `env:"FLAGR_RECORDER_KAFKA_PASSWORD" envDefault:""`
+	RecorderKafkaSASLUsername   string        `env:"FLAGR_RECORDER_KAFKA_SASL_USERNAME" envDefault:""`
+	RecorderKafkaSASLPassword   string        `env:"FLAGR_RECORDER_KAFKA_SASL_PASSWORD" envDefault:""`
 	RecorderKafkaVerbose        bool          `env:"FLAGR_RECORDER_KAFKA_VERBOSE" envDefault:"true"`
 	RecorderKafkaTopic          string        `env:"FLAGR_RECORDER_KAFKA_TOPIC" envDefault:"flagr-records"`
 	RecorderKafkaRetryMax       int           `env:"FLAGR_RECORDER_KAFKA_RETRYMAX" envDefault:"5"`

--- a/pkg/handler/data_recorder_kafka.go
+++ b/pkg/handler/data_recorder_kafka.go
@@ -43,11 +43,11 @@ var NewKafkaRecorder = func() DataRecorder {
 		cfg.Net.TLS.Config = tlscfg
 	}
 
-	if config.Config.RecorderKafkaUsername != "" && config.Config.RecorderKafkaPassword != "" {
+	if config.Config.RecorderKafkaSASLUsername != "" && config.Config.RecorderKafkaSASLPassword != "" {
 		cfg.Net.SASL.Enable = true
+		cfg.Net.SASL.User = config.Config.RecorderKafkaSASLUsername
+		cfg.Net.SASL.Password = config.Config.RecorderKafkaSASLPassword
 	}
-	cfg.Net.SASL.User = config.Config.RecorderKafkaUsername
-	cfg.Net.SASL.Password = config.Config.RecorderKafkaPassword
 
 	cfg.Producer.RequiredAcks = sarama.WaitForLocal
 	cfg.Producer.Retry.Max = config.Config.RecorderKafkaRetryMax

--- a/pkg/handler/data_recorder_kafka_test.go
+++ b/pkg/handler/data_recorder_kafka_test.go
@@ -42,6 +42,7 @@ func TestCreateTLSConfiguration(t *testing.T) {
 			"./testdata/certificates/alice.key",
 			"./testdata/certificates/ca.crt",
 			true,
+			false,
 		)
 		assert.NotZero(t, tlsConfig)
 
@@ -50,8 +51,18 @@ func TestCreateTLSConfiguration(t *testing.T) {
 			"",
 			"",
 			true,
+			false,
 		)
 		assert.Zero(t, tlsConfig)
+
+		tlsConfig = createTLSConfiguration(
+			"",
+			"",
+			"",
+			true,
+			true,
+		)
+		assert.NotZero(t, tlsConfig)
 	})
 
 	t.Run("cert or key file not found", func(t *testing.T) {
@@ -61,6 +72,7 @@ func TestCreateTLSConfiguration(t *testing.T) {
 				"./testdata/certificates/not_found.key",
 				"./testdata/certificates/ca.crt",
 				true,
+				false,
 			)
 		})
 	})
@@ -72,6 +84,7 @@ func TestCreateTLSConfiguration(t *testing.T) {
 				"./testdata/certificates/alice.key",
 				"./testdata/certificates/not_found.crt",
 				true,
+				false,
 			)
 		})
 	})

--- a/pkg/handler/export.go
+++ b/pkg/handler/export.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"math/rand"
 	"os"
+	"path"
 
 	"github.com/checkr/flagr/pkg/entity"
 	"github.com/checkr/flagr/swagger_gen/restapi/operations/export"
@@ -25,7 +26,7 @@ var exportSQLiteHandler = func(p export.GetExportSqliteParams) middleware.Respon
 }
 
 var exportSQLiteFile = func(excludeSnapshots *bool) (file io.ReadCloser, done func(), err error) {
-	fname := fmt.Sprintf("/tmp/flagr_%d.sqlite", rand.Int31())
+	fname := path.Join(os.TempDir(), fmt.Sprintf("flagr_%d.sqlite", rand.Int31()))
 	done = func() {
 		os.Remove(fname)
 		logrus.WithField("file", fname).Debugf("removing the tmp file")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This adds variables for authentication and enabling simple ssl without specifying certificates and others

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This should enable to use kafka with providers like confluent which uses sasl_plain over ssl.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I've tested it against our cluster which requires authentication with and ssl

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation. (I am not sure here, does the docs only point to config/env.go?)
- [ ] I have updated the documentation accordingly. (Same as aboce)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.