### PR TITLE
fix: Disable hover on cards inside cards

### DIFF
--- a/browser/flagr-ui/src/components/Flag.vue
+++ b/browser/flagr-ui/src/components/Flag.vue
@@ -98,7 +98,7 @@
                     </div>
                   </div>
                 </div>
-                <el-card shadow="hover" :class="toggleInnerConfigCard">
+                <el-card shadow="never" :class="toggleInnerConfigCard">
                   <div class="flex-row id-row">
                     <div class="flex-row-left">
                       <el-tag
@@ -250,7 +250,7 @@
                 </div>
                 <div class="variants-container-inner" v-if="flag.variants.length">
                   <div v-for="variant in flag.variants" :key="variant.id">
-                    <el-card shadow="hover">
+                    <el-card shadow="never">
                       <el-form label-position="left" label-width="100px">
                         <div class="flex-row id-row">
                           <el-tag type="primary" :disable-transitions="true">


### PR DESCRIPTION
## Description
Removes the hover shadow on cards on the flag page that are already inside other cards. The Segments cards make sense to have a hover since there is a drag action, however, the other cards do not have an action on click. The shadow is confusing.

Removes this hover shadow
![Kapture 2020-11-02 at 16 46 54](https://user-images.githubusercontent.com/1400464/97934629-10f19880-1d2b-11eb-9a4e-af8cc8f6816d.gif)


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.