### PR TITLE
Add dropdown by state to filter flags

### DIFF
--- a/browser/flagr-ui/src/components/Flags.vue
+++ b/browser/flagr-ui/src/components/Flags.vue
@@ -37,12 +37,26 @@
           </el-row>
 
           <el-row>
-            <el-input
-              placeholder="Search a flag"
-              prefix-icon="el-icon-search"
-              v-model="searchTerm"
-              v-focus
-            ></el-input>
+            <el-col :span="19">
+              <el-input
+                placeholder="Search a flag"
+                prefix-icon="el-icon-search"
+                v-model="searchTerm"
+                v-focus
+              ></el-input>
+            </el-col>
+            <el-col :span="4" :offset="1">
+              <template>
+                <el-select v-model="statusValue" placeholder="Filter by state">
+                  <el-option
+                    v-for="item in statusFilter"
+                    :key="item.value"
+                    :label="item.label"
+                    :value="item.value">
+                  </el-option>
+                </el-select>
+              </template>
+            </el-col>
           </el-row>
 
           <el-table
@@ -168,7 +182,18 @@ export default {
       searchTerm: "",
       newFlag: {
         description: ""
-      }
+      },
+      statusFilter: [{
+        value: 'all',
+        label: 'All the flags'
+      }, {
+        value: 'enabled',
+        label: 'Enabled flags'
+      }, {
+        value: 'disabled',
+        label: 'Disabled flags'
+      }],
+      statusValue: 'all'
     };
   },
   created() {
@@ -181,8 +206,13 @@ export default {
   },
   computed: {
     filteredFlags: function() {
-      if (this.searchTerm) {
-        return this.flags.filter(({ id, description, tags }) =>
+      if (this.searchTerm || this.statusValue != "all") {
+        return this.flags.filter(({ enabled }) =>
+          this.statusValue === "all" ||
+          (this.statusValue === "enabled" && enabled) ||
+          (this.statusValue === "disabled" && !enabled)
+        )
+        .filter(({ id, description, tags }) =>
           this.searchTerm
             .split(",")
             .map(term => {

--- a/browser/flagr-ui/src/components/Flags.vue
+++ b/browser/flagr-ui/src/components/Flags.vue
@@ -37,26 +37,12 @@
           </el-row>
 
           <el-row>
-            <el-col :span="19">
-              <el-input
-                placeholder="Search a flag"
-                prefix-icon="el-icon-search"
-                v-model="searchTerm"
-                v-focus
-              ></el-input>
-            </el-col>
-            <el-col :span="4" :offset="1">
-              <template>
-                <el-select v-model="statusValue" placeholder="Filter by state">
-                  <el-option
-                    v-for="item in statusFilter"
-                    :key="item.value"
-                    :label="item.label"
-                    :value="item.value">
-                  </el-option>
-                </el-select>
-              </template>
-            </el-col>
+            <el-input
+              placeholder="Search a flag"
+              prefix-icon="el-icon-search"
+              v-model="searchTerm"
+              v-focus
+            ></el-input>
           </el-row>
 
           <el-table
@@ -93,7 +79,9 @@
               sortable
               align="center"
               fixed="right"
-              width="100"
+              width="140"
+              :filters="[{ text: 'Enabled', value: true }, { text: 'Disabled', value: false }]"
+              :filter-method="filterTag"
             >
               <template slot-scope="scope">
                 <el-tag
@@ -182,18 +170,7 @@ export default {
       searchTerm: "",
       newFlag: {
         description: ""
-      },
-      statusFilter: [{
-        value: 'all',
-        label: 'All the flags'
-      }, {
-        value: 'enabled',
-        label: 'Enabled flags'
-      }, {
-        value: 'disabled',
-        label: 'Disabled flags'
-      }],
-      statusValue: 'all'
+      }
     };
   },
   created() {
@@ -206,13 +183,8 @@ export default {
   },
   computed: {
     filteredFlags: function() {
-      if (this.searchTerm || this.statusValue != "all") {
-        return this.flags.filter(({ enabled }) =>
-          this.statusValue === "all" ||
-          (this.statusValue === "enabled" && enabled) ||
-          (this.statusValue === "disabled" && !enabled)
-        )
-        .filter(({ id, description, tags }) =>
+      if (this.searchTerm) {
+        return this.flags.filter(({ id, description, tags }) =>
           this.searchTerm
             .split(",")
             .map(term => {
@@ -293,6 +265,9 @@ export default {
           self.deletedFlagsLoaded = true;
         }, handleErr.bind(this));
       }
+    },
+    filterTag(value, row) {
+      return row.enabled === value;
     }
   }
 };

--- a/browser/flagr-ui/src/components/Flags.vue
+++ b/browser/flagr-ui/src/components/Flags.vue
@@ -81,7 +81,7 @@
               fixed="right"
               width="140"
               :filters="[{ text: 'Enabled', value: true }, { text: 'Disabled', value: false }]"
-              :filter-method="filterTag"
+              :filter-method="filterStatus"
             >
               <template slot-scope="scope">
                 <el-tag
@@ -266,7 +266,7 @@ export default {
         }, handleErr.bind(this));
       }
     },
-    filterTag(value, row) {
+    filterStatus(value, row) {
       return row.enabled === value;
     }
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

In the home page we currently have a first row to add new flags and a second row to search for flags. We have modified the second row in order to show a dropdown list in which we can see the values \[`All the flags`, `Enabled flags`, `Disabled flags`\] being the value `All the flags` the one selected by default.

As the [current API](https://checkr.github.io/flagr/api_docs/#operation/findFlags) supports the boolean parameter `enabled` to filter flags by enabled and disabled, we only needed to change the GUI to add the filter.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The number of flags is growing and as this is a service shared by all of our customers, it is expected it will continue growing in the future. To do it easier to work with Flagr we want to provide a way of filtering flags by status (enabled / disabled).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

1. I added four flags: `Flag Y1`, `Flag Y2`, `Flag Z1` and `Flag Z2`.
2. I enabled flags `Flag Y1` and `Flag Z1`.
3. I selected `Enabled flags` and only `Flag Y1` and `Flag Z1` were shown (as expected).
4. I selected `Disabled flags` and only `Flag Y2` and `Flag Z2` were shown (as expected).
5. I selected `All the flags` and the four flags were shown (as expected).
6. I filtered by the term "Z" and only `Flag Z1` and `Flag Z2` were shown (as expected).
7. I selected `Enabled flags` and only `Flag Z1` was shown (as expected).
8. I selected `Disabled flags` and only `Flag Z2` was shown (as expected).
9. I removed the term "Z"only `Flag Z1` and `Flag Z2` were shown (as expected).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.