### PR TITLE
docs: update dev docs for Go 1.26, Vite, and recent features

### DIFF
--- a/docs/flagr_env.md
+++ b/docs/flagr_env.md
@@ -60,12 +60,11 @@ GOOGLE_APPLICATION_CREDENTIALS=/path/to/service/account.json
 > FYI: setting this env var will take over all Google's services on that environment.
 
 The best way to configure service account for Flagr to use pubsub only use:
-
 ```
 FLAGR_RECORDER_PUBSUB_PROJECT_ID=google-project-id
+FLAGR_RECORDER_PUBSUB_TOPIC_NAME=flagr-records
 FLAGR_RECORDER_PUBSUB_KEYFILE=/path/to/service/account.json
 ```
-
 Basic Authentication for web interface
 
 ```

--- a/docs/flagr_overview.md
+++ b/docs/flagr_overview.md
@@ -50,6 +50,6 @@ There are three components in the flagr, Flagr Evaluator, Flagr Manager, and Fla
   The lightweight endpoint `GET /api/v1/flags/snapshots/max_id` exposes the current max `flag_snapshot` id — a monotonically increasing version counter for the entire flag configuration. External caching layers (CDN, sidecar proxies, application-level caches) can poll this single endpoint and compare the value with their last-known version: if the value changed, at least one flag's configuration was modified and cached evaluations should be invalidated. This is vastly more efficient than polling individual flag records.
 
 - **Flagr Manager**. Flagr manager is the CRUD gateway. All the mutations of flags happen here.
-- **Flagr Metrics**. Flagr metrics is the data pipeline to collect evaluation results. Currently Flagr only supports Kafka as the pipeline.
+- **Flagr Metrics**. Flagr metrics is the data pipeline to collect evaluation results. Supported pipelines: Kafka, Kinesis, and Google Cloud Pub/Sub (configurable via `FLAGR_RECORDER_TYPE`).
 
 ![Flagr Architecture](images/flagr_arch.png)

--- a/docs/home.md
+++ b/docs/home.md
@@ -34,7 +34,7 @@ docker run -it -p 18000:18000 ghcr.io/openflagr/flagr
 
 Install Dependencies.
 
-- Go (1.24+)
+- Go (1.26+)
 - Make (for Makefile)
 - Node (20+) (for building UI)
 
@@ -46,18 +46,20 @@ git clone https://github.com/openflagr/flagr.git
 cd flagr
 
 # install dependencies, generate code, and start the service in
-# development mode
+# development mode (backend + frontend dev server)
 make build start
-```
 
-If you just want to run the pre-built backend (without the UI development service):
-
-```
+# Just run the pre-built backend (without UI dev server):
 make run
-```
 
-And alternatively to just run the UI service:
+# Just run the UI dev server (Vite on :8080, proxies API to :18000):
+cd browser/flagr-ui && npm run dev
 
-```
-make run_ui
-```
+# After backend changes, rebuild and restart in one step:
+make rebuild-run
+
+# Run e2e tests (builds Go binary, starts servers, runs Playwright):
+make test-e2e
+
+# Stop dev servers (port-based, safe for multi-project setups):
+make stop-ui


### PR DESCRIPTION
## Summary

Updates documentation to reflect recent changes in the codebase.

### Changes

- **`docs/home.md`**: Go version 1.24+ → 1.26+, restructured development section with current make commands (`rebuild-run`, `test-e2e`, `stop-ui`), mentioned Vite dev server
- **`docs/flagr_overview.md`**: Updated Metrics pipeline description from "only Kafka" to include Kafka, Kinesis, and Google Cloud Pub/Sub
- **`docs/flagr_env.md`**: Added `FLAGR_RECORDER_PUBSUB_TOPIC_NAME` to pubsub config example

### Notes

- README.md was reviewed and is already at the right high-level — no changes needed
- `docs/flagr_notifications.md`, `docs/flagr_use_cases.md`, `docs/flagr_debugging.md` are already current