### PR TITLE
fix: prevent duplicate rows when creating/restoring flags

### DIFF
--- a/browser/flagr-ui/e2e/flags-list.spec.js
+++ b/browser/flagr-ui/e2e/flags-list.spec.js
@@ -33,8 +33,9 @@ test.describe('Flags list page', () => {
 
     await expect(page.locator('.el-message--success')).toBeVisible({ timeout: 5000 })
 
-    // Verify the flag appears in the list
-    await expect(page.locator('[data-testid="flags-table"]')).toContainText(flagName)
+    // Verify the flag appears exactly once in the list (no duplicates)
+    const matchingRows = page.locator('[data-testid="flags-table"] .el-table__row', { hasText: flagName })
+    await expect(matchingRows).toHaveCount(1)
 
     // Capture the flag id for cleanup by reading it back from the API
     const r = await page.request.get(`${API}/flags?description=${encodeURIComponent(flagName)}`)

--- a/browser/flagr-ui/src/components/Flags.vue
+++ b/browser/flagr-ui/src/components/Flags.vue
@@ -317,7 +317,6 @@ export default {
         this.showCreateModal = false;
         this.$message.success("Flag created");
         this.flags.unshift(flag);
-        if (flagsCache) flagsCache.flags.unshift(flag);
       }, handleErr.bind(this));
     },
     restoreFlag(row) {
@@ -330,7 +329,6 @@ export default {
           const flag = response.data;
           this.$message.success(`Flag restored`);
           this.flags.push(flag);
-          if (flagsCache) flagsCache.flags.push(flag);
           this.deletedFlags = this.deletedFlags.filter(el => el.id !== flag.id);
         }, handleErr.bind(this));
       });


### PR DESCRIPTION
## Problem

Clicking "Create Flag" in the UI modal caused the new flag to appear as **two rows** in the flags list instead of one. Same bug existed when restoring a deleted flag.

## Root Cause

After `refreshFlags()` runs, `this.flags` and `flagsCache.flags` point to the **same array reference**. Both `createFlag()` and `restoreFlag()` called `.unshift()` / `.push()` on both — mutating the same array twice, inserting the element twice.

## Fix

Removed the redundant `flagsCache.flags` mutations in both methods. Since `this.flags === flagsCache.flags`, one mutation is sufficient.

**Files changed:**
- `browser/flagr-ui/src/components/Flags.vue` — removed duplicate array mutations
- `browser/flagr-ui/e2e/flags-list.spec.js` — added `toHaveCount(1)` assertion on newly created flag rows to prevent regressions

**Verification:** All 30 e2e tests pass.