### PR TITLE
refactor(ui): refine color palette and extract color tokens

### DIFF
--- a/browser/flagr-ui/src/components/MarkdownEditor.vue
+++ b/browser/flagr-ui/src/components/MarkdownEditor.vue
@@ -61,7 +61,7 @@ export default {
 
 <style lang="scss" scoped>
 .markdown-body {
-  background-color: #f6f8fa;
+  background-color: var(--el-fill-color-light);
   padding: 0.5rem;
 }
 </style>

--- a/browser/flagr-ui/src/components/SegmentsSection.vue
+++ b/browser/flagr-ui/src/components/SegmentsSection.vue
@@ -148,7 +148,7 @@ export default {
 
 <style lang="scss" scoped>
 .segment-card {
-  background: #fff;
+  background: var(--el-bg-color);
   border: 1px solid var(--el-border-color);
   border-radius: 10px;
   padding: var(--space-2xs) var(--space-xs);

--- a/browser/flagr-ui/src/components/VariantsSection.vue
+++ b/browser/flagr-ui/src/components/VariantsSection.vue
@@ -89,7 +89,7 @@ export default {
 .variant-item {
   flex: 1;
   min-width: 260px;
-  background: #fff;
+  background: var(--el-bg-color);
   border: 1px solid var(--el-border-color-light);
   border-radius: 8px;
   padding: var(--space-2xs) var(--space-xs);

--- a/browser/flagr-ui/src/styles/app.scss
+++ b/browser/flagr-ui/src/styles/app.scss
@@ -19,6 +19,15 @@ body {
   --space-md: 20px;
   --space-lg: 24px;
   --space-xl: 32px;
+
+  // --- Domain colors (not covered by Element Plus tokens) ---
+  // These are the only colors outside the --el-* system; keep them here
+  // so a retheme only touches two files: this block + element/index.scss.
+  --navbar-text: #ffffff;
+  --warning-tag-text: #97700a;
+  --warning-tag-bg: #faf3e0;
+  --diff-del-bg: #ecc9c9;
+  --diff-ins-bg: #cce3d6;
 }
 
 h1, h2 { font-weight: 600; }
@@ -35,7 +44,7 @@ ol { margin: 0; padding-left: 20px; }
   // --- Navbar ---
   .navbar {
     background-color: var(--el-color-primary);
-    color: #fff;
+    color: var(--navbar-text);
     padding: 0;
   }
   .navbar-inner {
@@ -221,8 +230,8 @@ ol { margin: 0; padding-left: 20px; }
     border: none;
     font-weight: 500;
     &--warning {
-      color: #b8860b;
-      background-color: #fef7e7;
+      color: var(--warning-tag-text);
+      background-color: var(--warning-tag-bg);
     }
     &--primary {
       color: var(--el-color-primary);
@@ -289,11 +298,11 @@ ol { margin: 0; padding-left: 20px; }
       line-height: 1.6;
       overflow-x: auto;
       del {
-        background-color: #f7b3b3;
+        background-color: var(--diff-del-bg);
         text-decoration: none;
       }
       ins {
-        background-color: #b6ddc6;
+        background-color: var(--diff-ins-bg);
         text-decoration: none;
       }
     }

--- a/browser/flagr-ui/src/styles/element/index.scss
+++ b/browser/flagr-ui/src/styles/element/index.scss
@@ -1,24 +1,27 @@
 @forward 'element-plus/theme-chalk/src/common/var.scss' with (
+  // --- Brand palette (single source of truth) ---
+  // Named SCSS vars so the palette reads as intent, not hex.
+  // Element Plus consumes these to generate --el-color-* CSS vars + light-N tints.
   $colors: (
     'white': #ffffff,
     'black': #000000,
     'primary': (
-      'base': #059669,
+      'base': #0d7d5a, // teal-green
     ),
     'success': (
-      'base': #059669,
+      'base': #0d7d5a,
     ),
     'warning': (
-      'base': #FBBF24,
+      'base': #c8931f, // rich amber
     ),
     'danger': (
-      'base': #F87171,
+      'base': #d05858, // terracotta
     ),
     'error': (
-      'base': #F87171,
+      'base': #d05858,
     ),
     'info': (
-      'base': #60A5FA,
+      'base': #4a8ad6, // slate blue
     ),
   ),
   $text-color: (
@@ -37,18 +40,18 @@
     'darker': #9CA3AF,
   ),
   $bg-color: (
-    '': #F9FAFB,
-    'page': #F3F4F6,
-    'overlay': #FCFCFC,
+    '': #FBFCFD,
+    'page': #EEF0F3,
+    'overlay': #FBFCFD,
   ),
   $fill-color: (
-    '': #F3F4F6,
-    'light': #F9FAFB,
-    'lighter': #ffffff,
-    'extra-light': #ffffff,
-    'dark': #E5E7EB,
-    'darker': #D1D5DB,
-    'blank': #ffffff,
+    '': #EEF0F3,
+    'light': #F4F6F8,
+    'lighter': #FBFCFD,
+    'extra-light': #FBFCFD,
+    'dark': #E1E4E8,
+    'darker': #C8CDD3,
+    'blank': #FEFEFE,
   ),
   $border-radius: (
     'base': 8px,


### PR DESCRIPTION
## Description

Refines the flagr-ui color system: softens overly-bright accents, improves card lift/hierarchy, and extracts all remaining hardcoded colors into a documented two-file token system.

### Accent palette (`styles/element/index.scss`)
Deepened and slightly desaturated every accent so the derived `light-7/8/9` tints Element Plus generates read calmer system-wide:

| Token | Before | After |
|---|---|---|
| primary / success | `#059669` (sat 93%, neon) | `#0d7d5a` (teal-green) |
| warning | `#FBBF24` (candy yellow) | `#c8931f` (rich amber) |
| danger / error | `#F87171` (light coral) | `#d05858` (terracotta) |
| info | `#60A5FA` (too light) | `#4a8ad6` (slate blue) |

### Background hierarchy (`styles/element/index.scss`)
The page→card lightness spread was only ~3%, so cards barely lifted off the page and felt too bright:
- page `#F3F4F6` → `#EEF0F3` (deeper, more lift)
- card/overlay `#F9FAFB` / `#FCFCFC` → `#FBFCFD` (off-white, less glare)
- fill-blank `#fff` → `#FEFEFE` (not pure white)

### Domain colors (`styles/app.scss`)
- Muted diff `del` (`#f7b3b3` → `#ecc9c9`) and `ins` (`#b6ddc6` → `#cce3d6`) backgrounds.
- Warmed warning-tag colors to match the new amber (`#b8860b`/`#fef7e7` → `#97700a`/`#faf3e0`).

### Tokenization
- `MarkdownEditor.vue`: `#f6f8fa` → `var(--el-fill-color-light)` (was a cool GitHub gray that clashed with the warm-neutral scale).
- `SegmentsSection.vue` / `VariantsSection.vue`: `#fff` → `var(--el-bg-color)`.
- Extracted the 5 remaining domain colors (`--navbar-text`, `--warning-tag-text/bg`, `--diff-del-bg`, `--diff-ins-bg`) into a documented `:root` custom-property block alongside the existing `--space-*` scale.

## Motivation and Context

The UI felt "too bright and not smooth/premium." Root cause: the neutral gray scale (Tailwind grays) was already solid, but the **accent colors were too saturated and too light**, fighting the muted neutral foundation. Additionally, several components used hardcoded hex backgrounds that bypassed the `--el-*` token system, and 5 one-off domain colors were buried mid-file in layout CSS — undiscoverable, unreusable.

After this change, a retheme touches only two files: `element/index.scss` (accents + neutrals, fed to Element Plus) and the `:root` block in `app.scss` (domain colors). No bare hex exists anywhere else in the codebase.

## How Has This Been Tested

- `npm run build` ✓ (1783 modules transformed, SCSS compiles cleanly)
- Verified via search that no hardcoded hex colors remain outside the two source-of-truth files
- Visual smoke test via Vite dev server + browser screenshot

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

_(Visual refinement — no behavioral changes.)_

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed. _(Visual-only; no test surface affected. Production build passes.)_