### PR TITLE
perf(handler): faster eval and batch evaluation

### DIFF
--- a/pkg/datar/engine_test.go
+++ b/pkg/datar/engine_test.go
@@ -91,6 +91,7 @@ func TestRecord_AfterCloseIsNoop(t *testing.T) {
 		t.Fatal("expected non-nil engine")
 		return
 	}
+	defer e.Shutdown()
 
 	e.closed.Store(true)
 	e.Record(1, 1, 1)

--- a/pkg/datar/engine_test.go
+++ b/pkg/datar/engine_test.go
@@ -89,8 +89,8 @@ func TestRecord_AfterCloseIsNoop(t *testing.T) {
 	e := New(newTestDB(t), true, time.Hour)
 	if e == nil {
 		t.Fatal("expected non-nil engine")
+		return
 	}
-	defer e.Shutdown()
 
 	e.closed.Store(true)
 	e.Record(1, 1, 1)

--- a/pkg/entity/flag.go
+++ b/pkg/entity/flag.go
@@ -31,6 +31,7 @@ type Flag struct {
 // FlagEvaluation is a struct that holds the necessary info for evaluation
 type FlagEvaluation struct {
 	VariantsMap map[uint]*Variant
+	TagValues   []string // denormalized tag values for eval results
 }
 
 // Preloads just the tags
@@ -68,8 +69,13 @@ func (f *Flag) PreloadTags(db *gorm.DB) error {
 
 // PrepareEvaluation prepares the information for evaluation
 func (f *Flag) PrepareEvaluation() error {
+	tagValues := make([]string, 0, len(f.Tags))
+	for _, tag := range f.Tags {
+		tagValues = append(tagValues, tag.Value)
+	}
 	f.FlagEvaluation = FlagEvaluation{
 		VariantsMap: make(map[uint]*Variant),
+		TagValues:   tagValues,
 	}
 	for i := range f.Segments {
 		if err := f.Segments[i].PrepareEvaluation(); err != nil {

--- a/pkg/handler/eval.go
+++ b/pkg/handler/eval.go
@@ -52,7 +52,6 @@ func (e *eval) PostEvaluationBatch(params evaluation.PostEvaluationBatchParams) 
 	flagKeys := params.Body.FlagKeys
 	flagTags := params.Body.FlagTags
 	flagTagsOperator := params.Body.FlagTagsOperator
-	results := &models.EvaluationBatchResponse{}
 
 	// Deduplicate flagKeys to prevent DoS via repeated keys
 	if len(flagKeys) > 1 {
@@ -92,6 +91,14 @@ func (e *eval) PostEvaluationBatch(params evaluation.PostEvaluationBatchParams) 
 			return evaluation.NewPostEvaluationBatchDefault(400).WithPayload(
 				ErrorMessage("batch evaluation size %d exceeds maximum allowed size of %d", total, maxBatchSize))
 		}
+	}
+
+	est := len(entities) * (len(flagIDs) + len(flagKeys))
+	if len(flagTags) > 0 {
+		est += len(entities)
+	}
+	results := &models.EvaluationBatchResponse{
+		EvaluationResults: make([]*models.EvalResult, 0, est),
 	}
 
 	// TODO make it concurrent
@@ -144,19 +151,16 @@ func BlankResult(f *entity.Flag, evalContext models.EvalContext, msg string) *mo
 	flagID := uint(0)
 	flagKey := ""
 	flagSnapshotID := uint(0)
-	flagTags := []string{}
+	var flagTags []string
 	if f != nil {
 		flagID = f.ID
 		flagSnapshotID = f.SnapshotID
 		flagKey = f.Key
-		if len(f.Tags) > 0 {
-			for _, tag := range f.Tags {
-				flagTags = append(flagTags, tag.Value)
-			}
-		}
+		flagTags = f.FlagEvaluation.TagValues
 	}
+	ec := evalContext
 	return &models.EvalResult{
-		EvalContext: &evalContext,
+		EvalContext: &ec,
 		EvalDebugLog: &models.EvalDebugLog{
 			Msg:              msg,
 			SegmentDebugLogs: nil,
@@ -183,7 +187,7 @@ var LookupFlag = func(evalContext models.EvalContext) *entity.Flag {
 var EvalFlagsByTags = func(evalContext models.EvalContext) []*models.EvalResult {
 	cache := GetEvalCache()
 	fs := cache.GetByTags(evalContext.FlagTags, evalContext.FlagTagsOperator)
-	results := []*models.EvalResult{}
+	results := make([]*models.EvalResult, 0, len(fs))
 	for _, f := range fs {
 		results = append(results, EvalFlagWithContext(f, evalContext))
 	}
@@ -220,18 +224,20 @@ var EvalFlagWithContext = func(flag *entity.Flag, evalContext models.EvalContext
 		evalContext.EntityType = flag.EntityType
 	}
 
-	logs := []*models.SegmentDebugLog{}
 	var vID int64
 	var sID int64
-
+	var logs []*models.SegmentDebugLog
+	if config.Config.EvalDebugEnabled && evalContext.EnableDebug {
+		logs = make([]*models.SegmentDebugLog, 0, len(flag.Segments))
+	}
 	for _, segment := range flag.Segments {
 		sID = int64(segment.ID)
-		variantID, log, evalNextSegment := evalSegment(flag.ID, evalContext, segment)
-		if config.Config.EvalDebugEnabled && evalContext.EnableDebug {
-			logs = append(logs, log)
-		}
+		variantID, log, evalNextSegment := evalSegment(evalContext, segment)
 		if variantID != nil {
 			vID = int64(*variantID)
+		}
+		if config.Config.EvalDebugEnabled && evalContext.EnableDebug {
+			logs = append(logs, log)
 		}
 		if !evalNextSegment {
 			break
@@ -303,7 +309,6 @@ var logEvalResultToPrometheus = func(r *models.EvalResult) {
 }
 
 var evalSegment = func(
-	flagID uint,
 	evalContext models.EvalContext,
 	segment entity.Segment,
 ) (
@@ -311,12 +316,16 @@ var evalSegment = func(
 	log *models.SegmentDebugLog,
 	evalNextSegment bool,
 ) {
+	debug := config.Config.EvalDebugEnabled && evalContext.EnableDebug
+
 	if len(segment.Constraints) != 0 {
 		m, ok := evalContext.EntityContext.(map[string]any)
 		if !ok {
-			log = &models.SegmentDebugLog{
-				Msg:       fmt.Sprintf("constraints are present in the segment_id %v, but got invalid entity_context: %s.", segment.ID, spew.Sdump(evalContext.EntityContext)),
-				SegmentID: int64(segment.ID),
+			if debug {
+				log = &models.SegmentDebugLog{
+					Msg:       fmt.Sprintf("constraints are present in the segment_id %v, but got invalid entity_context: %s.", segment.ID, spew.Sdump(evalContext.EntityContext)),
+					SegmentID: int64(segment.ID),
+				}
 			}
 			return nil, log, true
 		}
@@ -324,7 +333,7 @@ var evalSegment = func(
 		expr := segment.SegmentEvaluation.ConditionsExpr
 		match, err := conditions.Evaluate(expr, m)
 		if err != nil {
-			if config.Config.EvalDebugEnabled && evalContext.EnableDebug {
+			if debug {
 				log = &models.SegmentDebugLog{
 					Msg:       err.Error(),
 					SegmentID: int64(segment.ID),
@@ -333,9 +342,9 @@ var evalSegment = func(
 			return nil, log, true
 		}
 		if !match {
-			if config.Config.EvalDebugEnabled && evalContext.EnableDebug {
+			if debug {
 				log = &models.SegmentDebugLog{
-					Msg:       debugConstraintMsg(evalContext.EnableDebug, expr, m),
+					Msg:       debugConstraintMsg(true, expr, m),
 					SegmentID: int64(segment.ID),
 				}
 			}
@@ -343,19 +352,28 @@ var evalSegment = func(
 		}
 	}
 
-	vID, debugMsg := segment.SegmentEvaluation.DistributionArray.Rollout(
-		evalContext.EntityID,
-		segment.SegmentEvaluation.FlagIDStr, // pre-formatted during PrepareEvaluation
-		segment.RolloutPercent,
-	)
-
-	log = &models.SegmentDebugLog{
-		Msg:       "matched all constraints. " + debugMsg,
-		SegmentID: int64(segment.ID),
+	var debugMsg string
+	if debug {
+		vID, debugMsg = segment.SegmentEvaluation.DistributionArray.Rollout(
+			evalContext.EntityID,
+			segment.SegmentEvaluation.FlagIDStr,
+			segment.RolloutPercent,
+		)
+	} else {
+		vID, _ = segment.SegmentEvaluation.DistributionArray.Rollout(
+			evalContext.EntityID,
+			segment.SegmentEvaluation.FlagIDStr,
+			segment.RolloutPercent,
+		)
 	}
 
-	// at this point, all constraints are matched, so we shouldn't go to next segment
-	// thus setting evalNextSegment = false
+	if debug {
+		log = &models.SegmentDebugLog{
+			Msg:       "matched all constraints. " + debugMsg,
+			SegmentID: int64(segment.ID),
+		}
+	}
+
 	return vID, log, false
 }
 

--- a/pkg/handler/eval_test.go
+++ b/pkg/handler/eval_test.go
@@ -20,17 +20,17 @@ import (
 func TestEvalSegment(t *testing.T) {
 	t.Run("test empty evalContext", func(t *testing.T) {
 		s := entity.GenFixtureSegment()
-		vID, log, evalNextSegment := evalSegment(100, models.EvalContext{}, s)
+		vID, log, evalNextSegment := evalSegment(models.EvalContext{}, s)
 
 		assert.Nil(t, vID)
-		assert.NotEmpty(t, log)
+		assert.Nil(t, log)
 		assert.True(t, evalNextSegment)
 	})
 
 	t.Run("test happy code path", func(t *testing.T) {
 		s := entity.GenFixtureSegment()
 		s.RolloutPercent = uint(100)
-		vID, log, evalNextSegment := evalSegment(100, models.EvalContext{
+		vID, log, evalNextSegment := evalSegment(models.EvalContext{
 			EnableDebug:   true,
 			EntityContext: map[string]any{"dl_state": "CA"},
 			EntityID:      "entityID1",
@@ -46,7 +46,7 @@ func TestEvalSegment(t *testing.T) {
 	t.Run("test constraint evaluation error", func(t *testing.T) {
 		s := entity.GenFixtureSegment()
 		s.RolloutPercent = uint(100)
-		vID, log, evalNextSegment := evalSegment(100, models.EvalContext{
+		vID, log, evalNextSegment := evalSegment(models.EvalContext{
 			EnableDebug:   true,
 			EntityContext: map[string]any{},
 			EntityID:      "entityID1",
@@ -62,7 +62,7 @@ func TestEvalSegment(t *testing.T) {
 	t.Run("test constraint not match", func(t *testing.T) {
 		s := entity.GenFixtureSegment()
 		s.RolloutPercent = uint(100)
-		vID, log, evalNextSegment := evalSegment(100, models.EvalContext{
+		vID, log, evalNextSegment := evalSegment(models.EvalContext{
 			EnableDebug:   true,
 			EntityContext: map[string]any{"dl_state": "NY"},
 			EntityID:      "entityID1",
@@ -78,7 +78,7 @@ func TestEvalSegment(t *testing.T) {
 	t.Run("test evalContext wrong format", func(t *testing.T) {
 		s := entity.GenFixtureSegment()
 		s.RolloutPercent = uint(100)
-		vID, log, evalNextSegment := evalSegment(100, models.EvalContext{
+		vID, log, evalNextSegment := evalSegment(models.EvalContext{
 			EnableDebug:   true,
 			EntityContext: nil,
 			EntityID:      "entityID1",
@@ -105,7 +105,7 @@ func TestEvalSegment(t *testing.T) {
 		}
 		s.PrepareEvaluation()
 
-		vID, log, evalNextSegment := evalSegment(100, models.EvalContext{
+		vID, log, evalNextSegment := evalSegment(models.EvalContext{
 			EnableDebug:   true,
 			EntityContext: map[string]any{"foo": float64(9990403)},
 			EntityID:      "entityID1",
@@ -132,7 +132,7 @@ func TestEvalSegment(t *testing.T) {
 		}
 		s.PrepareEvaluation()
 
-		vID, log, evalNextSegment := evalSegment(100, models.EvalContext{
+		vID, log, evalNextSegment := evalSegment(models.EvalContext{
 			EnableDebug:   true,
 			EntityContext: map[string]any{"foo": float64(9990404)},
 			EntityID:      "entityID1",
@@ -163,7 +163,7 @@ func TestEvalSegment_NestedEntityContext(t *testing.T) {
 		}
 		s.PrepareEvaluation()
 
-		vID, log, evalNextSegment := evalSegment(100, models.EvalContext{
+		vID, log, evalNextSegment := evalSegment(models.EvalContext{
 			EnableDebug: true,
 			EntityContext: map[string]any{
 				"user": map[string]any{
@@ -192,7 +192,7 @@ func TestEvalSegment_NestedEntityContext(t *testing.T) {
 		}
 		s.PrepareEvaluation()
 
-		vID, log, evalNextSegment := evalSegment(100, models.EvalContext{
+		vID, log, evalNextSegment := evalSegment(models.EvalContext{
 			EnableDebug:   true,
 			EntityContext: map[string]any{"user": map[string]any{"name": "Bob"}},
 			EntityID:      "entityID1",
@@ -216,7 +216,7 @@ func TestEvalSegment_NestedEntityContext(t *testing.T) {
 		}
 		s.PrepareEvaluation()
 
-		vID, log, evalNextSegment := evalSegment(100, models.EvalContext{
+		vID, log, evalNextSegment := evalSegment(models.EvalContext{
 			EnableDebug:   true,
 			EntityContext: map[string]any{"roles": []any{"admin", "editor"}},
 			EntityID:      "entityID1",
@@ -240,7 +240,7 @@ func TestEvalSegment_NestedEntityContext(t *testing.T) {
 		}
 		s.PrepareEvaluation()
 
-		vID, log, evalNextSegment := evalSegment(100, models.EvalContext{
+		vID, log, evalNextSegment := evalSegment(models.EvalContext{
 			EnableDebug: true,
 			EntityContext: map[string]any{
 				"users": []any{
@@ -270,7 +270,7 @@ func TestEvalSegment_NestedEntityContext(t *testing.T) {
 
 		// When a nested key is missing, the constraint evaluation should error
 		// and the segment should not match (evalNextSegment = true means try next)
-		vID, log, evalNextSegment := evalSegment(100, models.EvalContext{
+		vID, log, evalNextSegment := evalSegment(models.EvalContext{
 			EnableDebug:   true,
 			EntityContext: map[string]any{"user": map[string]any{"name": "Alice"}},
 			EntityID:      "entityID1",


### PR DESCRIPTION
## Description

Improves evaluation and batch evaluation performance by reducing allocations on the hot path and tightening debug-only work.

**Handler (`pkg/handler/eval.go`)**
- Pre-size `EvaluationBatchResponse.EvaluationResults` after flag ID/key deduplication
- Pre-size `EvalFlagsByTags` result slice
- `BlankResult` uses precomputed `FlagEvaluation.TagValues` instead of rebuilding tags per eval
- `evalSegment` only allocates `SegmentDebugLog` when `EvalDebugEnabled && EnableDebug`
- `Rollout` debug message only computed when debug is on
- Removed unused `flagID` argument from `evalSegment` (rollout salt uses `segment.SegmentEvaluation.FlagIDStr`)

**Entity (`pkg/entity/flag.go`)**
- `FlagEvaluation.TagValues` populated in `PrepareEvaluation()`

**Tests**
- `TestEvalSegment` empty-context case expects no debug log when debug is off
- `evalSegment` call sites updated for new signature
- `pkg/datar/engine_test.go`: explicit return after `t.Fatal` for staticcheck SA5011

**Note:** Session work also patched `vendor/github.com/zhouzhuojie/conditions` (per-eval resolve cache, bool singletons, AND/OR fast path). That vendor diff is **not** in this commit. Consider upstreaming to [zhouzhuojie/conditions](https://github.com/zhouzhuojie/conditions) and bumping `go.mod` in a follow-up for the largest constraint-eval wins.

## Motivation and Context

Flagr’s eval path is allocation-heavy in batch mode (~4.8k allocs/op in benchmarks). These changes target repeatable wins without API changes: cache-time denormalization, batch slice capacity, and avoiding debug structures in production eval.

## How Has This Been Tested?

- `go test ./pkg/entity/... ./pkg/handler/... ./pkg/datar/...`
- `make verify_lint` (0 issues)
- `go test -benchmem -run=^$ -bench 'BenchmarkEval|BenchmarkPost' ./pkg/handler/...` (local arm64; batch allocs ~3811/op vs ~4819/op baseline from session)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue) — test/staticcheck hygiene
- [x] New feature (non-breaking change which adds functionality) — performance improvements
- [ ] Breaking change

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes. (adjusted existing tests)
- [x] All new and existing tests passed.