### PR TITLE
docs(exposure): pipeline guide, entityContext-only, lint & swagger fixes

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,9 @@
+# IDE golangci-lint extension; CI uses Makefile verify_lint flags on ./pkg/...
+version: "2"
+run:
+  timeout: 5m
+  build-tags:
+    - integration
+linters:
+  disable:
+    - errcheck

--- a/README.md
+++ b/README.md
@@ -33,13 +33,16 @@ Flagr is an open source Go service that delivers the right experience to the rig
 
 | Page | Content |
 |------|---------|
+| [Home](https://openflagr.github.io/flagr/) | Quick start, dev, testing, deploy |
 | [Overview](https://openflagr.github.io/flagr/#/flagr_overview) | Concepts, running example, architecture |
-| [Use Cases](https://openflagr.github.io/flagr/#/flagr_use_cases) | Feature flagging, A/B testing, dynamic configuration patterns |
-| [Server Configuration](https://openflagr.github.io/flagr/#/flagr_env) | All environment variables, database drivers, auth, data recorders |
-| [JSON Flag Source](https://openflagr.github.io/flagr/#/flagr_json_flag_spec) | GitOps workflows, JSON format spec, validator, CI integration |
-| [Datar Analytics](https://openflagr.github.io/flagr/#/flagr_datar) | In-memory aggregate analytics engine |
-| [Exposure Logging](https://openflagr.github.io/flagr/#/flagr_exposure) | Client-reported impressions for A/B testing |
-| [Notifications](https://openflagr.github.io/flagr/#/flagr_notifications) | Webhook configuration and payload format |
+| [Use Cases](https://openflagr.github.io/flagr/#/flagr_use_cases) | Feature flags, A/B testing, dynamic configuration |
+| [Debug Console](https://openflagr.github.io/flagr/#/flagr_debugging) | UI evaluation testing |
+| [Server Configuration](https://openflagr.github.io/flagr/#/flagr_env) | Environment variables, DB, auth, recorders |
+| [JSON Flag Source](https://openflagr.github.io/flagr/#/flagr_json_flag_spec) | GitOps, JSON format, validator |
+| [Notifications](https://openflagr.github.io/flagr/#/flagr_notifications) | Webhooks on flag changes |
+| [Exposure Logging](https://openflagr.github.io/flagr/#/flagr_exposure) | `POST /exposures` API |
+| [Data Recorders & A/B Analysis](https://openflagr.github.io/flagr/#/flagr_eval_exposure_pipeline) | Kafka, Kinesis, Pub/Sub; sample consumer; A/B analytics |
+| [Datar Analytics](https://openflagr.github.io/flagr/#/flagr_datar) | In-process eval aggregates |
 | [API Reference](https://openflagr.github.io/flagr/api_docs) | Swagger/OpenAPI spec |
 
 ---

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -3,11 +3,13 @@
     - [Overview](flagr_overview.md)
     - [Use Cases](flagr_use_cases.md)
     - [Debug Console](flagr_debugging.md)
-- Configuration
+- Server & deployment
     - [Environment Variables](flagr_env.md)
     - [JSON Flag Source (GitOps)](flagr_json_flag_spec.md)
     - [Notifications](flagr_notifications.md)
+- Event recording & analytics
     - [Exposure Logging](flagr_exposure.md)
+    - [Data Recorders & A/B Analysis](flagr_eval_exposure_pipeline.md)
     - [Datar Analytics](flagr_datar.md)
 - Development
     - [Testing](home?id=testing)

--- a/docs/api_docs/bundle.yaml
+++ b/docs/api_docs/bundle.yaml
@@ -1142,8 +1142,8 @@ definitions:
           $ref: '#/definitions/variant'
       dataRecordsEnabled:
         description: >-
-          enabled data records will get data logging in the metrics pipeline,
-          for example, kafka.
+          when true and FLAGR_RECORDER_ENABLED is set, evaluation and exposure
+          rows are written to configured data recorders (e.g. kafka).
         type: boolean
       entityType:
         description: >-
@@ -1184,8 +1184,8 @@ definitions:
       dataRecordsEnabled:
         type: boolean
         description: >-
-          enabled data records will get data logging in the metrics pipeline,
-          for example, kafka.
+          when true and FLAGR_RECORDER_ENABLED is set, evaluation and exposure
+          rows are written to configured data recorders (e.g. kafka).
         x-nullable: true
       entityType:
         description: it will overwrite entityType into evaluation logs if it's not empty
@@ -1520,8 +1520,8 @@ definitions:
       recordSource:
         type: string
         description: >-
-          evaluation for eval API results; exposure for POST /exposures pipeline
-          events
+          evaluation for eval API results; exposure for client-reported
+          impressions via POST /exposures (same data recorders as eval)
         enum:
           - evaluation
           - exposure
@@ -1650,15 +1650,16 @@ definitions:
       entityContext:
         type: object
         additionalProperties: true
+        description: >-
+          Optional attributes recorded on evalContext.entityContext (same field
+          as POST /evaluation). Include impression-specific keys here (e.g. page
+          path); exposure does not re-run segment constraints.
       flagSnapshotID:
         type: integer
         format: int64
       timestamp:
         type: string
         format: date-time
-      metadata:
-        type: object
-        additionalProperties: true
   exposuresResponse:
     type: object
     properties:

--- a/docs/api_docs/bundle.yaml
+++ b/docs/api_docs/bundle.yaml
@@ -1210,7 +1210,6 @@ definitions:
   flagSnapshot:
     type: object
     required:
-      - id
       - flag
       - updatedAt
     properties:

--- a/docs/flagr_datar.md
+++ b/docs/flagr_datar.md
@@ -12,6 +12,9 @@ Prometheus covers rate-based metrics and variant-level time-series well, but it 
 - **Historic totals** — cumulative counts (not just rates) over days or weeks
 - **Per-flag dashboards** — a simple summary view across all flags without setting up a separate analytics stack
 
+For **client-reported impressions** and warehouse-style A/B analysis, use [Exposure Logging](flagr_exposure.md) and [Data Recorders & A/B Analysis](flagr_eval_exposure_pipeline.md) (Kafka, Kinesis, or Pub/Sub). Datar does not ingest exposure rows.
+
+
 ## Enabling
 
 Requires `FLAGR_RECORDER_ENABLED=true`. With the master switch on, list `datar` in `RecorderType` to activate the in-memory aggregator:
@@ -119,3 +122,4 @@ A unique index on `(flag_id, variant_id, segment_id, bucket_hour)` ensures addit
 - Data is in-memory until the periodic flush. If the process crashes, up to one flush interval of aggregate data is lost (acceptable for dashboard analytics).
 - No data retention policy is built in — the table grows unbounded. Deploy a cron job or retention policy if needed.
 - No unique entity counting (HyperLogLog or similar). Each evaluation is counted once regardless of the entity identity.
+- **Evaluations only** — rows with `recordSource: exposure` from `POST /exposures` are not counted. Use a streaming recorder (Kafka, Kinesis, or Pub/Sub) and [Data Recorders & A/B Analysis](flagr_eval_exposure_pipeline.md) for impression-based experiments.

--- a/docs/flagr_debugging.md
+++ b/docs/flagr_debugging.md
@@ -2,6 +2,8 @@
 
 The Debug Console is a built-in UI tool for testing flag evaluation without leaving the browser. It appears on each flag's detail page and wraps the evaluation API in an interactive JSON editor.
 
+The console exercises `POST /evaluation` only. For production **impression** logging after render, see [Exposure Logging](flagr_exposure.md). Concepts (segments, constraints, rollout) are in the [Overview](flagr_overview.md).
+
 ![Debug Console](/images/demo_debugging_console.png)
 
 ## What it does

--- a/docs/flagr_env.md
+++ b/docs/flagr_env.md
@@ -47,11 +47,17 @@ Flagr supports JWT-based authentication for API access. Configure the signing ke
 
 ## Data record destinations
 
+Flagr can emit **evaluation** and **exposure** rows to one or more backends when `FLAGR_RECORDER_ENABLED=true` and the flag has `dataRecordsEnabled: true`.
 
-Evaluation results and client-reported **exposures** (`POST /api/v1/exposures`) share the same data recorder gate when per-flag `dataRecordsEnabled` is on. Exposure rows include `recordSource: "exposure"` in the recorded payload. See [Exposure Logging](flagr_exposure.md).
+| Goal | Doc |
+|------|-----|
+| Exposure API (`POST /exposures`) | [Exposure Logging](flagr_exposure.md) |
+| Stream eval + exposure to your pipeline (Kafka, Kinesis, or Pub/Sub) + A/B patterns | [Data Recorders & A/B Analysis](flagr_eval_exposure_pipeline.md) |
+| Built-in eval counts only (no stream, no exposures) | [Datar Analytics](flagr_datar.md) |
 
-`FLAGR_EXPOSURE_BATCH_SIZE` (default **100**) caps rows per `POST /api/v1/exposures` request.
-Flagr can send evaluation results to one or more destinations simultaneously. Set `FLAGR_RECORDER_ENABLED=true` and list the desired recorders in `FLAGR_RECORDER_TYPE` (comma-separated, e.g. `kafka,datar`).
+Exposure rows use `recordSource: "exposure"` on the same wire shape as evaluations. `FLAGR_EXPOSURE_BATCH_SIZE` (default **100**) caps rows per exposure request.
+
+Set `FLAGR_RECORDER_TYPE` to a comma-separated list (e.g. `kafka`, `kafka,datar`).
 
 ### Kafka (default)
 
@@ -63,6 +69,8 @@ FLAGR_RECORDER_KAFKA_TOPIC=flagr-records
 ```
 
 Additional Kafka options include SSL/TLS (`FLAGR_RECORDER_KAFKA_CERTFILE`, `FLAGR_RECORDER_KAFKA_KEYFILE`, `FLAGR_RECORDER_KAFKA_CAFILE`), SASL authentication (`FLAGR_RECORDER_KAFKA_SASL_USERNAME`, `FLAGR_RECORDER_KAFKA_SASL_PASSWORD`), idempotent producers, and encryption. See [env.go](https://github.com/openflagr/flagr/blob/master/pkg/config/env.go) for the full list.
+
+For consuming eval and exposure events (any streaming recorder) and A/B analysis, see [Data Recorders & A/B Analysis](flagr_eval_exposure_pipeline.md).
 
 ### Kinesis (AWS)
 
@@ -77,6 +85,8 @@ AWS_DEFAULT_REGION=eu-central-1
 Other options include credentials files, container credentials, and instance profiles. See the [AWS documentation](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html#config-settings-and-precedence).
 
 Make sure the IAM key has permissions to push records to the Kinesis stream.
+
+Kinesis and Pub/Sub use the same **record frame** as Kafka for both evaluation and exposure rows. See [Data Recorders & A/B Analysis](flagr_eval_exposure_pipeline.md).
 
 ### Pub/Sub (Google Cloud)
 

--- a/docs/flagr_eval_exposure_pipeline.md
+++ b/docs/flagr_eval_exposure_pipeline.md
@@ -158,8 +158,7 @@ curl -X POST "http://flagr:18000/api/v1/exposures" \
       "entityID": "user-123",
       "entityType": "user",
       "flagSnapshotID": 42,
-      "entityContext": { "country": "US" },
-      "metadata": { "page": "/checkout" }
+      "entityContext": { "country": "US", "page": "/checkout" }
     }]
   }'
 ```
@@ -274,7 +273,7 @@ flowchart LR
 ```
 
 1. **Assignment table** (optional): from `evaluation` rows — who was bucketed into which variant and segment at eval time. Useful for debugging bucketing and `flagSnapshotID` alignment.
-2. **Exposure fact table** (recommended denominator): from `exposure` rows — `entity_id`, `flag_id`, `variant_id`, `flag_snapshot_id`, `timestamp`, context/metadata.
+2. **Exposure fact table** (recommended denominator): from `exposure` rows — `entity_id`, `flag_id`, `variant_id`, `flag_snapshot_id`, `timestamp`, and `evalContext.entityContext` (one JSON object per row).
 3. **Outcome events**: purchases, signups, clicks — from your app analytics, **not** from Flagr.
 4. **Join** outcomes to **exposures** on `entity_id` (and flag/experiment id), with a **time window** (e.g. outcome within 7 days after first exposure). Use **first exposure per entity per experiment** for classic A/B unless you intentionally analyze repeated views.
 

--- a/docs/flagr_eval_exposure_pipeline.md
+++ b/docs/flagr_eval_exposure_pipeline.md
@@ -1,0 +1,354 @@
+# Data Recorders & A/B Analysis
+
+Flagr is an **evaluation engine**: it assigns variants and can **emit events** to your data pipeline. It does **not** run experiment analytics (conversion rates, significance tests, warehouse modeling). That work belongs in **your** consumers, warehouse, and BI tools.
+
+This guide covers:
+
+1. **Data recorders** — how eval and exposure rows reach Kafka, Kinesis, Pub/Sub, or Datar.
+2. **Wire format** — same `evalResult` JSON for every streaming recorder.
+3. **Downstream handling** — including a **minimal Kafka consumer** as one example.
+4. **A/B analysis** — why you need exposures, not just evaluations.
+
+For the exposure API, see [Exposure Logging](flagr_exposure.md). For in-process eval counts only (no exposures), see [Datar](flagr_datar.md). Recorder env vars: [Environment Variables](flagr_env.md#data-record-destinations).
+
+---
+
+## Two event types on one wire shape
+
+Both paths write the same **`evalResult`** JSON (see [API `evalResult`](https://openflagr.github.io/flagr/api_docs)), distinguished by **`recordSource`**:
+
+| `recordSource` | Produced by | Meaning |
+|----------------|-------------|---------|
+| `evaluation` | `POST /evaluation` (and batch) | Server **assignment** for this request: which variant (if any) the evaluator returned for the entity. Includes “blank” outcomes (flag disabled, not found, no segment match) when those are logged. |
+| `exposure` | `POST /exposures` | Client-reported **impression**: the user **saw** the experiment surface for that flag/variant (or flag only if variant omitted). |
+
+**Do not** treat `evaluation` as “user saw the treatment” or `exposure` as “user was assigned.” For conversion analysis you almost always need **exposures** (or your own impression signal) as the experiment **denominator**.
+
+---
+
+## Data recorders (where events go)
+
+When `FLAGR_RECORDER_ENABLED=true` and a flag has `dataRecordsEnabled: true`, both **evaluation** and **exposure** rows are passed to `GetDataRecorder().AsyncRecord`. A **fan-out** sends each row to every recorder listed in `FLAGR_RECORDER_TYPE` (comma-separated).
+
+| Recorder | `FLAGR_RECORDER_TYPE` | Eval + exposure streaming? | Notes |
+|----------|----------------------|----------------------------|--------|
+| **Kafka** | `kafka` | Yes — same serialized frame | Common default; [example consumer](#example-kafka-consumer-python) below |
+| **Kinesis** | `kinesis` | Yes — same frame bytes on the stream | AWS; partition key = `entityID` from the frame |
+| **Pub/Sub** | `pubsub` | Yes — same frame as message payload | Google Cloud |
+| **Datar** | `datar` | **Eval only** | Skips `recordSource: exposure`; REST aggregates, not a warehouse |
+
+You can combine recorders, e.g. `kafka,datar` (stream to Kafka **and** keep lightweight eval totals in Flagr).
+
+**Exposure logging does not require Kafka.** Any streaming recorder above receives exposure rows with `recordSource: "exposure"` using the same JSON envelope as evaluations. Configure the backend your org already uses; parsing and analytics below apply to all streaming recorders.
+
+---
+
+## Enable recording
+
+Per-flag **`dataRecordsEnabled`** must be `true`, and the server must have recorders enabled.
+
+**Example — Kafka** (for Kinesis or Pub/Sub, set `FLAGR_RECORDER_TYPE` and see [Environment Variables](flagr_env.md)):
+
+```bash
+export FLAGR_RECORDER_ENABLED=true
+export FLAGR_RECORDER_TYPE=kafka
+export FLAGR_RECORDER_KAFKA_BROKERS=kafka1:9092,kafka2:9092
+export FLAGR_RECORDER_KAFKA_TOPIC=flagr-records
+export FLAGR_RECORDER_KAFKA_PARTITION_KEY_ENABLED=true
+```
+
+**Example — Kinesis only:**
+
+```bash
+export FLAGR_RECORDER_ENABLED=true
+export FLAGR_RECORDER_TYPE=kinesis
+export FLAGR_RECORDER_KINESIS_STREAM_NAME=flagr-records
+```
+
+**Example — Pub/Sub only:**
+
+```bash
+export FLAGR_RECORDER_ENABLED=true
+export FLAGR_RECORDER_TYPE=pubsub
+export FLAGR_RECORDER_PUBSUB_PROJECT_ID=my-project
+export FLAGR_RECORDER_PUBSUB_TOPIC_NAME=flagr-records
+```
+
+Create or update the flag:
+
+```bash
+curl -X PUT "http://flagr:18000/api/v1/flags/1" \
+  -H 'Content-Type: application/json' \
+  -d '{"dataRecordsEnabled": true}'
+```
+
+After changing `dataRecordsEnabled`, wait for the eval cache refresh (default ~3s) before expecting records.
+
+**Datar:** rows with `recordSource: exposure` are **not** counted in Datar. **Kafka, Kinesis, and Pub/Sub** still receive exposure rows when configured.
+
+---
+
+## Record frame format (Kafka, Kinesis, Pub/Sub)
+
+Default mode wraps the eval result in an outer object with a string **`payload`** (JSON-serialized `evalResult`):
+
+```json
+{
+  "payload": "{\"evalContext\":{\"entityID\":\"user-123\",\"entityType\":\"user\",\"entityContext\":{\"country\":\"US\"}},\"flagID\":1,\"flagKey\":\"checkout-button\",\"flagSnapshotID\":42,\"segmentID\":10,\"variantID\":2,\"variantKey\":\"treatment\",\"timestamp\":\"2026-06-25T12:00:00Z\",\"recordSource\":\"evaluation\"}",
+  "encrypted": false
+}
+```
+
+With `FLAGR_RECORDER_FRAME_OUTPUT_MODE=payload_raw_json`, `payload` is embedded JSON instead of a string:
+
+```json
+{
+  "payload": {
+    "flagID": 1,
+    "flagKey": "checkout-button",
+    "recordSource": "exposure",
+    "segmentID": 0,
+    "variantID": 2,
+    "variantKey": "treatment",
+    "evalContext": { "entityID": "user-123" },
+    "timestamp": "2026-06-25T12:00:00Z"
+  }
+}
+```
+
+Partition key (Kafka when `FLAGR_RECORDER_KAFKA_PARTITION_KEY_ENABLED`; Kinesis uses the same `entityID` from the frame) is **`evalContext.entityID`**, useful for co-locating one user’s events.
+
+---
+
+## Client responsibilities
+
+### Evaluation (assignment)
+
+Call when you need a variant **now** (server-side bucketing):
+
+```bash
+curl -X POST "http://flagr:18000/api/v1/evaluation" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "entityID": "user-123",
+    "entityType": "user",
+    "entityContext": { "country": "US" },
+    "flagID": 1
+  }'
+```
+
+The data recorder may persist an `evaluation` row when gates pass. That row reflects **this eval call**, not necessarily that the user later viewed the UI.
+
+### Exposure (impression)
+
+Recommended flow for UI experiments:
+
+1. **Evaluate** → cache `variantID` / `variantKey` / `flagSnapshotID` client-side.
+2. **Render** the experiment (button, copy, layout).
+3. **Log exposure** when the surface is actually visible (on mount, in-viewport, or batched on unload):
+
+```bash
+curl -X POST "http://flagr:18000/api/v1/exposures" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "exposures": [{
+      "flagID": 1,
+      "variantID": 2,
+      "variantKey": "treatment",
+      "entityID": "user-123",
+      "entityType": "user",
+      "flagSnapshotID": 42,
+      "entityContext": { "country": "US" },
+      "metadata": { "page": "/checkout" }
+    }]
+  }'
+```
+
+Omit `variantID` / `variantKey` if you only need “saw something for this flag.” Include them when analysis is **per variant**.
+
+---
+
+## Example: Kafka consumer (Python) {#example-kafka-consumer-python}
+
+Kafka is one common destination; **Kinesis and Pub/Sub publish the same outer JSON**—only your client library changes. Read messages, parse `payload`, branch on `recordSource`. This is **not** production-grade (no auth, DLQ, schema registry)—it shows the parsing contract.
+
+```
+#!/usr/bin/env python3
+"""Minimal Flagr Kafka consumer — eval vs exposure."""
+
+import json
+import sys
+from kafka import KafkaConsumer
+
+TOPIC = "flagr-records"
+BOOTSTRAP = ["localhost:9092"]
+
+
+def parse_eval_result(message_value: bytes) -> dict | None:
+    outer = json.loads(message_value)
+    payload = outer.get("payload")
+    if payload is None:
+        return None
+    if isinstance(payload, str):
+        return json.loads(payload)
+    if isinstance(payload, dict):
+        return payload
+    return None
+
+
+def main():
+    consumer = KafkaConsumer(
+        TOPIC,
+        bootstrap_servers=BOOTSTRAP,
+        auto_offset_reset="earliest",
+        enable_auto_commit=True,
+        group_id="flagr-example-consumer",
+    )
+    for msg in consumer:
+        record = parse_eval_result(msg.value)
+        if not record:
+            continue
+
+        source = record.get("recordSource") or "evaluation"
+        entity_id = (record.get("evalContext") or {}).get("entityID")
+        flag_key = record.get("flagKey")
+        variant_key = record.get("variantKey")
+        snapshot_id = record.get("flagSnapshotID")
+
+        if source == "exposure":
+            # Impression — use for experiment denominators
+            print(
+                "EXPOSURE",
+                entity_id,
+                flag_key,
+                variant_key,
+                f"snapshot={snapshot_id}",
+                file=sys.stderr,
+            )
+        elif source == "evaluation":
+            # Assignment log — QA, funnel debugging, not a substitute for exposure
+            print(
+                "EVAL",
+                entity_id,
+                flag_key,
+                variant_key,
+                f"segment={record.get('segmentID')}",
+                file=sys.stderr,
+            )
+        else:
+            print("UNKNOWN recordSource", source, file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()
+```
+
+Install: `pip install kafka-python`. In production, prefer your org’s stream processor (Flink, Spark, ksqlDB, Lambda, etc.) with the same **`recordSource`** branch.
+
+---
+
+## Using eval + exposure for real A/B analysis
+
+### The problem with eval-only metrics
+
+If you count **`evaluation`** rows as “users in the experiment,” you inflate or mis-assign denominators:
+
+- Eval runs **before** render (prefetch, SSR, background refresh) → user may never see the UI.
+- Eval runs on **every** navigation while exposure should fire **once per meaningful view** (your client rules).
+- Eval logs **failed** paths (`recordSource` still `evaluation`) with empty or zero variant — not experiment participants.
+- **Holdouts** and **rollout %** mean assignment exists without a visible treatment unless you gate rendering.
+
+**Exposure** (or an equivalent impression event you own) aligns the denominator with **people who could react** to the variant.
+
+### A simple legitimate workflow
+
+```mermaid
+flowchart LR
+  A[POST /evaluation] --> B[Client caches assignment]
+  B --> C[Render experiment UI]
+  C --> D[POST /exposures]
+  D --> E[Recorder exposure rows]
+  F[App events e.g. purchase] --> G[Your analytics DB]
+  E --> G
+  G --> H[Metrics per variant]
+```
+
+1. **Assignment table** (optional): from `evaluation` rows — who was bucketed into which variant and segment at eval time. Useful for debugging bucketing and `flagSnapshotID` alignment.
+2. **Exposure fact table** (recommended denominator): from `exposure` rows — `entity_id`, `flag_id`, `variant_id`, `flag_snapshot_id`, `timestamp`, context/metadata.
+3. **Outcome events**: purchases, signups, clicks — from your app analytics, **not** from Flagr.
+4. **Join** outcomes to **exposures** on `entity_id` (and flag/experiment id), with a **time window** (e.g. outcome within 7 days after first exposure). Use **first exposure per entity per experiment** for classic A/B unless you intentionally analyze repeated views.
+
+### Example metrics (conceptual SQL)
+
+**Exposure counts by variant** (denominator):
+
+```sql
+SELECT
+  variant_key,
+  COUNT(DISTINCT entity_id) AS exposed_users
+FROM fact_exposure
+WHERE flag_key = 'checkout-button'
+  AND event_date BETWEEN '2026-06-01' AND '2026-06-30'
+GROUP BY variant_key;
+```
+
+**Conversion rate** (needs your outcome table):
+
+```sql
+WITH first_exposure AS (
+  SELECT entity_id, variant_key, MIN(exposed_at) AS first_exposed_at
+  FROM fact_exposure
+  WHERE flag_key = 'checkout-button'
+  GROUP BY entity_id, variant_key
+),
+conversions AS (
+  SELECT user_id AS entity_id, MIN(converted_at) AS converted_at
+  FROM fact_purchases
+  GROUP BY user_id
+)
+SELECT
+  e.variant_key,
+  COUNT(DISTINCT e.entity_id) AS exposed,
+  COUNT(DISTINCT c.entity_id) AS converted,
+  COUNT(DISTINCT c.entity_id) * 1.0 / NULLIF(COUNT(DISTINCT e.entity_id), 0) AS conversion_rate
+FROM first_exposure e
+LEFT JOIN conversions c
+  ON e.entity_id = c.entity_id
+  AND c.converted_at >= e.first_exposed_at
+  AND c.converted_at < e.first_exposed_at + INTERVAL '7 days'
+GROUP BY e.variant_key;
+```
+
+Run significance tests (chi-square, Bayesian, sequential methods) in your warehouse or notebook — Flagr does not compute them.
+
+### `flagSnapshotID` and config changes
+
+Clients may send **`flagSnapshotID`** from the eval response on exposure rows. Downstream, join to your snapshot dimension so analysis uses the **flag version active at impression time**, not today’s config. Flagr passes the ID through; **validating** snapshot/flag pairing is your warehouse’s job.
+
+### When evaluation rows are still useful
+
+- **Volume and latency** monitoring of the eval API.
+- **Segment distribution** checks (`segmentID` on eval rows).
+- **Sanity checks**: assignment without matching exposures (integration bugs, ad blockers, never-rendered paths).
+- **Server-side experiments** with no UI (API-only flags) where “exposure” may be defined as “request handled with variant applied” — you may log custom exposure at that point or define denominators from eval **explicitly** in your methodology (document the choice).
+
+---
+
+## Operational checklist
+
+| Check | Action |
+|-------|--------|
+| No records in your stream | `FLAGR_RECORDER_ENABLED`, `FLAGR_RECORDER_TYPE`, backend config (brokers/stream/topic), flag `dataRecordsEnabled` |
+| Only eval, no exposure | Client must call `POST /exposures`; eval does not create exposure rows |
+| Exposures in stream but not Datar | Expected — Datar skips `recordSource: exposure` |
+| Duplicate exposures | Client deduping (once per session/view); consumer `COUNT DISTINCT` or first-exposure logic |
+| GDPR / deletion | Entity IDs are in `evalContext.entityID`; handle in your retention pipeline |
+
+---
+
+## Related docs
+
+- [Exposure Logging](flagr_exposure.md) — API, validation, Statsd
+- [Environment Variables](flagr_env.md) — Kafka, Kinesis, Pub/Sub, Datar settings
+- [Datar](flagr_datar.md) — in-process eval aggregates (not a substitute for exposure-based A/B)
+- [Overview](flagr_overview.md) — segments, rollout, distribution concepts

--- a/docs/flagr_exposure.md
+++ b/docs/flagr_exposure.md
@@ -2,6 +2,8 @@
 
 Exposure logging records when a user **actually saw** a flag or experiment surface, separate from `POST /evaluation` (assignment). Typical flow: evaluate to get a variant, cache the result client-side, then call `POST /exposures` when the UI renders.
 
+For data recorders (Kafka, Kinesis, Pub/Sub), wire format, a sample Kafka consumer, and A/B analysis, see [Data Recorders & A/B Analysis](flagr_eval_exposure_pipeline.md).
+
 ## Endpoint
 
 `POST /api/v1/exposures`
@@ -46,10 +48,10 @@ Single impressions use an array of one item. Maximum batch size: `FLAGR_EXPOSURE
 Same gate as evaluation data records:
 
 1. `FLAGR_RECORDER_ENABLED=true`
-2. Recorder type configured (e.g. `kafka`)
+2. At least one recorder in `FLAGR_RECORDER_TYPE` (e.g. `kafka`, `kinesis`, `pubsub` — not `datar` alone if you need a stream)
 3. Per-flag `dataRecordsEnabled: true`
 
-Recorded rows use the same `evalResult` JSON shape as evaluations (same Kafka topic when Kafka is configured), with `recordSource: "exposure"`. **Datar does not count exposures.** Exposure ingest uses separate Statsd metrics (`exposure.ingest`, `exposure.recorded`).
+Recorded rows use the same `evalResult` JSON shape as evaluations on **Kafka, Kinesis, and Pub/Sub**, with `recordSource: "exposure"`. **Datar does not count exposures.** Exposure ingest uses separate Statsd metrics (`exposure.ingest`, `exposure.recorded`).
 
 ## How this connects to evaluation and `AsyncRecord`
 
@@ -63,7 +65,7 @@ Recorded rows use the same `evalResult` JSON shape as evaluations (same Kafka to
 
 `json_file` / `json_http` nodes with eval-only setup register **evaluation** only; **`POST /exposures` is not available** on those deployments.
 
-### Kafka / warehouse consumers
+### Downstream consumers (Kafka, Kinesis, Pub/Sub)
 
 Filter or branch on `recordSource`:
 
@@ -88,4 +90,4 @@ Separate from eval `evaluation` metric: `exposure.ingest` (tags: `status=accepte
 
 Auth matches `POST /evaluation`.
 
-See [plan](../plans/2026-06-25-001-exposure-logging-plan.md) for design decisions.
+Design notes are in the repo under `docs/plans/2026-06-25-001-exposure-logging-plan.md` ([view on GitHub](https://github.com/openflagr/flagr/blob/master/docs/plans/2026-06-25-001-exposure-logging-plan.md)).

--- a/docs/flagr_exposure.md
+++ b/docs/flagr_exposure.md
@@ -18,14 +18,17 @@ Request body:
       "variantKey": "treatment",
       "entityID": "user-123",
       "entityType": "user",
-      "entityContext": { "country": "US" },
-      "metadata": { "page": "/checkout" },
+      "entityContext": { "country": "US", "page": "/checkout" },
       "flagSnapshotID": 42,
       "timestamp": "2026-06-25T12:00:00Z"
     }
   ]
 }
 ```
+
+### `entityContext`
+
+Use the same **`entityContext`** object as `POST /evaluation`: any optional JSON object is stored on the recorded row as `evalContext.entityContext` (for your warehouse or analytics). Put segment-style attributes (`country`, `tier`) and impression-specific attributes (`page`, `component`) in one map — there is no separate `metadata` field. Exposure ingest does **not** re-run segment constraints; context is only copied onto the data record.
 
 Single impressions use an array of one item. Maximum batch size: `FLAGR_EXPOSURE_BATCH_SIZE` (default **100**).
 

--- a/docs/flagr_overview.md
+++ b/docs/flagr_overview.md
@@ -50,6 +50,14 @@ There are three components in the flagr, Flagr Evaluator, Flagr Manager, and Fla
   The lightweight endpoint `GET /api/v1/flags/snapshots/max_id` exposes the current max `flag_snapshot` id — a monotonically increasing version counter for the entire flag configuration. External caching layers (CDN, sidecar proxies, application-level caches) can poll this single endpoint and compare the value with their last-known version: if the value changed, at least one flag's configuration was modified and cached evaluations should be invalidated. This is vastly more efficient than polling individual flag records.
 
 - **Flagr Manager**. Flagr manager is the CRUD gateway. All the mutations of flags happen here.
-- **Flagr Metrics**. Evaluation results and client-reported exposures (`POST /api/v1/exposures`) flow through the same **data recorders** when per-flag `dataRecordsEnabled` is on. Supports Kafka (default), AWS Kinesis, Google Pub/Sub, and Datar. Exposures use `recordSource: exposure` and do not update Datar aggregates. Multiple recorders via `FLAGR_RECORDER_TYPE`.
+- **Flagr Metrics**. Evaluation results and client-reported exposures (`POST /api/v1/exposures`) flow through the same **data recorders** when per-flag `dataRecordsEnabled` is on. Streaming options: **Kafka**, **AWS Kinesis**, and **Google Pub/Sub** (same wire format for eval and exposure). **Datar** is eval-only and skips exposure rows. Combine recorders via `FLAGR_RECORDER_TYPE`. See [Data Recorders & A/B Analysis](flagr_eval_exposure_pipeline.md).
 
 ![Flagr Architecture](images/flagr_arch.png)
+
+## Related documentation
+
+- [Use Cases](flagr_use_cases.md) — how to instrument apps for flags, experiments, and dynamic config
+- [Exposure Logging](flagr_exposure.md) and [Data Recorders & A/B Analysis](flagr_eval_exposure_pipeline.md) — impressions and pipeline analytics
+- [Datar](flagr_datar.md) — optional built-in eval counters
+- [Environment Variables](flagr_env.md) — deployment and recorder configuration
+

--- a/docs/flagr_use_cases.md
+++ b/docs/flagr_use_cases.md
@@ -91,6 +91,7 @@ UI setting example (frontend looks may iterate quickly):
 ![ab testing setting demo 1](/images/demo_exp1.png)
 ![ab testing setting demo 2](/images/demo_exp2.png)
 
+For **measuring experiment outcomes** (conversion rates, etc.), assignment from `POST /evaluation` is not enough—you need **impression** events. Use [Exposure Logging](flagr_exposure.md) when the user sees the treatment, then [Data Recorders & A/B Analysis](flagr_eval_exposure_pipeline.md) (or your own consumer on Kinesis/Pub/Sub) to build denominators and join to business metrics. For quick **eval volume** only, see [Datar](flagr_datar.md).
 
 ## Dynamic Configuration
 

--- a/docs/home.md
+++ b/docs/home.md
@@ -4,6 +4,24 @@ Flagr is an open source Go service that delivers the right experience to the rig
 
 For a deeper introduction, see the [Flagr Overview](flagr_overview).
 
+## Documentation map
+
+| If you want to… | Start here |
+|-----------------|------------|
+| Learn concepts (flags, segments, rollout) | [Overview](flagr_overview) |
+| See code patterns for flags / A/B / config | [Use Cases](flagr_use_cases) |
+| Configure the server (DB, auth, recorders) | [Environment Variables](flagr_env) |
+| Run flags from Git (no DB) | [JSON Flag Source](flagr_json_flag_spec) |
+| Log impressions after eval (`POST /exposures`) | [Exposure Logging](flagr_exposure) |
+| Ship eval + exposure to a data recorder and analyze A/B | [Data Recorders & A/B Analysis](flagr_eval_exposure_pipeline) |
+| Quick eval counts inside Flagr (no pipeline) | [Datar Analytics](flagr_datar) |
+| Test evaluation in the UI | [Debug Console](flagr_debugging) |
+| Webhooks on flag changes | [Notifications](flagr_notifications) |
+| REST API details | [API Reference](https://openflagr.github.io/flagr/api_docs) |
+
+**Event recording:** [Exposure](flagr_exposure) (API) → [Data Recorders & A/B Analysis](flagr_eval_exposure_pipeline) → [Datar](flagr_datar) (built-in eval-only aggregates). Env vars: [Data record destinations](flagr_env?id=data-record-destinations).
+
+
 ## What can Flagr do?
 
 | Capability | Highlights |
@@ -12,7 +30,7 @@ For a deeper introduction, see the [Flagr Overview](flagr_overview).
 | **A/B testing** | Multi-variant experiments with deterministic distribution |
 | **Dynamic configuration** | Per-variant JSON attachments for runtime config |
 | **GitOps / Flags-as-code** | Load flags from JSON files or HTTP URLs; manage in Git, validate in CI |
-| **Exposure logging** | `POST /exposures` for impressions after assignment; shares data recorder gate with eval |
+| **Exposure logging** | `POST /exposures` after the user sees the variant — [Exposure](flagr_exposure), [Data Recorders & A/B Analysis](flagr_eval_exposure_pipeline) |
 | **Webhook notifications** | HTTP POST on every flag change, with retry and backoff |
 | **Multi-database** | SQLite (dev), MySQL, PostgreSQL, JSON sources |
 

--- a/docs/plans/2026-06-25-001-exposure-logging-plan.md
+++ b/docs/plans/2026-06-25-001-exposure-logging-plan.md
@@ -24,7 +24,7 @@ Explicit client-reported exposure (impression) logging complements `POST /evalua
 | `flagSnapshotID` | Optional; if set, pass through on the record; if omitted, use flag `SnapshotID` from eval cache (no DB validation; downstream joins) |
 | Disabled flag | Allowed |
 | `timestamp` | Client RFC3339 if valid, else server now |
-| Context | Merge `entityContext` + `metadata` → `evalContext.entityContext` |
+| Context | Optional `entityContext` → `evalContext.entityContext` on the record (same as eval; no separate `metadata` field) |
 | `entityType` | Flag `entityType` overrides client (same as eval) |
 
 ### Response
@@ -54,7 +54,7 @@ Same middleware as `POST /evaluation`. No dedicated rate limit v1.
 
 ## Implementation notes
 
-- Single `pkg/handler/exposure.go`: `PostExposures`, `buildExposureDataRecord` (returns result + flag), `resolveExposureFlag`, `resolveExposureVariant`, `mergeJSONIntoMap`.
+- Single `pkg/handler/exposure.go`: `PostExposures`, `buildExposureDataRecord` (returns result + flag), `resolveExposureFlag`, `resolveExposureVariant`.
 - Naming: **`dataRecord`** / **`buildExposureDataRecord`** / “data recorders” (not “pipeline”).
 - No thin wrappers around `AsyncRecord`; exposures never call `logEvalResult`.
 - Ingest is **cache-only** for flags/variants (no re-segmentation, no snapshot DB lookup); **one cache lookup per accepted row** (no second `GetByFlagKeyOrID` in the loop).
@@ -86,6 +86,8 @@ Post-implementation:
 - Dropped `recordPipelineEvent` / shared validation modules; direct `AsyncRecord` in eval and exposure.
 - Docs/tests aligned with data-recorder vocabulary; operator sections in `flagr_exposure.md`.
 - **`flagSnapshotID`**: pass-through only (removed `getDB` validation) — warehouse validates snapshot/flag pairing.
+
+- **2026-06-26:** Dropped exposure `metadata`; clients use `entityContext` only (aligned with `POST /evaluation`).
 
 ## Code quality review (2026-06-25, updated post thermo-nuclear follow-up)
 

--- a/integration_tests/integration_server_test.go
+++ b/integration_tests/integration_server_test.go
@@ -65,7 +65,6 @@ func TestMain(m *testing.M) {
 	url := os.Getenv("FLAGR_SERVER_URL")
 	if url == "" {
 		url = startLocalServer()
-		_ = os.Setenv("FLAGR_RECORDER_ENABLED", "true")
 		defer func() {
 			if serverCmd != nil {
 				serverCmd.Process.Kill()

--- a/integration_tests/integration_server_test.go
+++ b/integration_tests/integration_server_test.go
@@ -65,6 +65,7 @@ func TestMain(m *testing.M) {
 	url := os.Getenv("FLAGR_SERVER_URL")
 	if url == "" {
 		url = startLocalServer()
+		_ = os.Setenv("FLAGR_RECORDER_ENABLED", "true")
 		defer func() {
 			if serverCmd != nil {
 				serverCmd.Process.Kill()
@@ -159,10 +160,11 @@ func startLocalServer() string {
 	serverCmd = exec.Command(binPath,
 		"--port", strconv.Itoa(port),
 	)
-	serverCmd.Dir = projectRoot
 	serverCmd.Env = append(os.Environ(),
 		"FLAGR_DB_DBDRIVER=sqlite3",
 		"FLAGR_DB_DBCONNECTIONSTR=file::memory:?cache=shared",
+		"FLAGR_RECORDER_ENABLED=true",
+		"FLAGR_RECORDER_TYPE=datar",
 	)
 	// Redirect server output to a temp file to avoid "I/O incomplete" errors
 	// when the test binary kills the server process.

--- a/integration_tests/integration_test.go
+++ b/integration_tests/integration_test.go
@@ -9,10 +9,12 @@
 //
 // Execution modes:
 //   - Local:   go test -tags=integration ./integration_tests/
-//              (auto-starts server with SQLite :memory:)
+//              (auto-starts server with SQLite :memory:, recorder on)
 //   - BYO:     FLAGR_SERVER_URL=http://host:18000 go test -tags=integration ./integration_tests/
 //   - Docker:  cd integration_tests && make test
 //              (builds binary, runs against all 6 compose instances)
+//
+// TestIntegration_Exposures asserts POST /exposures recording via loggedCount (no test-process FLAGR_RECORDER_ENABLED).
 package flagr_integration
 
 import (
@@ -21,7 +23,6 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"os"
 	"testing"
 	"time"
 )
@@ -544,11 +545,56 @@ func TestIntegration_BatchEvalOperator(t *testing.T) {
 	}
 }
 
+// assertExposureRecorderGate polls until a valid exposure row is written (loggedCount==1).
+// The Flagr server must have FLAGR_RECORDER_ENABLED and per-flag dataRecordsEnabled.
+func assertExposureRecorderGate(t *testing.T, flagID int64) {
+	t.Helper()
+	err := pollUntil("exposure recorder gate", "/api/v1/exposures", 15*time.Second, func() bool {
+		r, err := doReq("POST", "/api/v1/exposures", map[string]any{
+			"exposures": []map[string]any{{
+				"flagID":   flagID,
+				"entityID": "exposure-cache-warmup",
+			}},
+		})
+		if err != nil {
+			return false
+		}
+		defer r.Body.Close()
+		if r.StatusCode < 200 || r.StatusCode >= 300 {
+			return false
+		}
+		var warm struct {
+			LoggedCount int64 `json:"loggedCount"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&warm); err != nil {
+			return false
+		}
+		return warm.LoggedCount == 1
+	})
+	if err != nil {
+		t.Fatalf("exposure logging not recording after dataRecordsEnabled (server needs FLAGR_RECORDER_ENABLED): %v", err)
+	}
+	t.Log("exposure recorder gate: loggedCount=1")
+}
+
 func TestIntegration_Exposures(t *testing.T) {
 	if len(seedFlagIDs) < 2 {
 		t.Fatal("need at least 2 seeded flags")
 	}
 	flagID := seedFlagIDs[1]
+
+	avail, err := doReq("POST", "/api/v1/exposures", map[string]any{
+		"exposures": []map[string]any{{"flagID": flagID, "entityID": "exposure-probe"}},
+	})
+	if err != nil {
+		t.Fatalf("POST /exposures probe: %v", err)
+	}
+	io.Copy(io.Discard, avail.Body)
+	avail.Body.Close()
+	if avail.StatusCode == http.StatusNotFound {
+		t.Skip("POST /exposures not available on this server (e.g. checkr/flagr:1.1.12)")
+	}
+
 	doReqOK(t, "PUT", fmt.Sprintf("/api/v1/flags/%d", flagID), map[string]any{
 		"dataRecordsEnabled": true,
 	})
@@ -558,63 +604,26 @@ func TestIntegration_Exposures(t *testing.T) {
 		t.Fatalf("expected dataRecordsEnabled=true on flag %d", flagID)
 	}
 
-	if os.Getenv("FLAGR_RECORDER_ENABLED") == "true" {
-		err := pollUntil("exposure recorder gate", "/api/v1/exposures", 15*time.Second, func() bool {
-			r, err := doReq("POST", "/api/v1/exposures", map[string]any{
-				"exposures": []map[string]any{{
-					"flagID":   flagID,
-					"entityID": "exposure-cache-warmup",
-				}},
-			})
-			if err != nil {
-				return false
-			}
-			defer r.Body.Close()
-			if r.StatusCode < 200 || r.StatusCode >= 300 {
-				return false
-			}
-			var warm struct {
-				LoggedCount int64 `json:"loggedCount"`
-			}
-			if err := json.NewDecoder(r.Body).Decode(&warm); err != nil {
-				return false
-			}
-			return warm.LoggedCount == 1
-		})
-		if err != nil {
-			t.Fatalf("exposure never recorded after enabling dataRecordsEnabled: %v", err)
-		}
-	}
+	assertExposureRecorderGate(t, flagID)
 
-	eid := "exposure-test-entity"
 	body := map[string]any{
 		"exposures": []map[string]any{
-			{
-				"flagID":   flagID,
-				"entityID": eid,
-			},
-			{
-				"entityID": "bad-row-no-flag",
-			},
+			{"flagID": flagID, "entityID": "exposure-test-entity"},
+			{"entityID": "bad-row-no-flag"},
 		},
 	}
-
 	probe, err := doReq("POST", "/api/v1/exposures", body)
 	if err != nil {
 		t.Fatalf("POST /exposures: %v", err)
 	}
 	defer probe.Body.Close()
-	if probe.StatusCode == http.StatusNotFound {
-		t.Skip("POST /exposures not available on this server (e.g. checkr/flagr:1.1.12)")
-	}
 	if probe.StatusCode < 200 || probe.StatusCode >= 300 {
 		b, _ := io.ReadAll(probe.Body)
 		t.Fatalf("POST /exposures: expected 2xx, got %d: %s", probe.StatusCode, b)
 	}
 
 	var resp struct {
-		LoggedCount int64  `json:"loggedCount"`
-		Message     string `json:"message"`
+		LoggedCount int64 `json:"loggedCount"`
 		Errors      []struct {
 			Index   int64  `json:"index"`
 			Message string `json:"message"`
@@ -629,14 +638,11 @@ func TestIntegration_Exposures(t *testing.T) {
 	if resp.Errors[0].Index != 1 {
 		t.Fatalf("expected error index 1, got %d", resp.Errors[0].Index)
 	}
-	wantLogged := int64(0)
-	if os.Getenv("FLAGR_RECORDER_ENABLED") == "true" {
-		wantLogged = 1
-	}
-	if resp.LoggedCount != wantLogged {
-		t.Fatalf("loggedCount want %d (recorder enabled=%v), got %d", wantLogged, wantLogged == 1, resp.LoggedCount)
+	if resp.LoggedCount != 1 {
+		t.Fatalf("loggedCount want 1 after recorder gate, got %d", resp.LoggedCount)
 	}
 }
+
 // ---------------------------------------------------------------------------
 // Datar integration tests
 // ---------------------------------------------------------------------------

--- a/integration_tests/integration_test.go
+++ b/integration_tests/integration_test.go
@@ -17,10 +17,11 @@ package flagr_integration
 
 import (
 	"encoding/json"
-	"io"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
+	"os"
 	"testing"
 	"time"
 )
@@ -543,9 +544,48 @@ func TestIntegration_BatchEvalOperator(t *testing.T) {
 	}
 }
 
-
 func TestIntegration_Exposures(t *testing.T) {
+	if len(seedFlagIDs) < 2 {
+		t.Fatal("need at least 2 seeded flags")
+	}
 	flagID := seedFlagIDs[1]
+	doReqOK(t, "PUT", fmt.Sprintf("/api/v1/flags/%d", flagID), map[string]any{
+		"dataRecordsEnabled": true,
+	})
+	var flag flagResponse
+	getJSON(t, fmt.Sprintf("/api/v1/flags/%d", flagID), &flag)
+	if !flag.DataRecordsEnabled {
+		t.Fatalf("expected dataRecordsEnabled=true on flag %d", flagID)
+	}
+
+	if os.Getenv("FLAGR_RECORDER_ENABLED") == "true" {
+		err := pollUntil("exposure recorder gate", "/api/v1/exposures", 15*time.Second, func() bool {
+			r, err := doReq("POST", "/api/v1/exposures", map[string]any{
+				"exposures": []map[string]any{{
+					"flagID":   flagID,
+					"entityID": "exposure-cache-warmup",
+				}},
+			})
+			if err != nil {
+				return false
+			}
+			defer r.Body.Close()
+			if r.StatusCode < 200 || r.StatusCode >= 300 {
+				return false
+			}
+			var warm struct {
+				LoggedCount int64 `json:"loggedCount"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&warm); err != nil {
+				return false
+			}
+			return warm.LoggedCount == 1
+		})
+		if err != nil {
+			t.Fatalf("exposure never recorded after enabling dataRecordsEnabled: %v", err)
+		}
+	}
+
 	eid := "exposure-test-entity"
 	body := map[string]any{
 		"exposures": []map[string]any{
@@ -589,8 +629,12 @@ func TestIntegration_Exposures(t *testing.T) {
 	if resp.Errors[0].Index != 1 {
 		t.Fatalf("expected error index 1, got %d", resp.Errors[0].Index)
 	}
-	if resp.LoggedCount != 0 && resp.LoggedCount != 1 {
-		t.Fatalf("loggedCount want 0 or 1, got %d", resp.LoggedCount)
+	wantLogged := int64(0)
+	if os.Getenv("FLAGR_RECORDER_ENABLED") == "true" {
+		wantLogged = 1
+	}
+	if resp.LoggedCount != wantLogged {
+		t.Fatalf("loggedCount want %d (recorder enabled=%v), got %d", wantLogged, wantLogged == 1, resp.LoggedCount)
 	}
 }
 // ---------------------------------------------------------------------------

--- a/pkg/handler/data_recorder.go
+++ b/pkg/handler/data_recorder.go
@@ -38,6 +38,16 @@ func dataRecordEnabled(flag *entity.Flag) bool {
 	return flag != nil && flag.DataRecordsEnabled && config.Config.RecorderEnabled
 }
 
+// recordSourcePolicy centralizes how client-reported exposure rows differ from
+// eval API rows on the same EvalResult wire shape.
+func recordCountsTowardDatar(r models.EvalResult) bool {
+	return r.RecordSource != models.EvalResultRecordSourceExposure
+}
+
+func recordCountsTowardEvalKafkaStatsd(r models.EvalResult) bool {
+	return r.RecordSource != models.EvalResultRecordSourceExposure
+}
+
 // GetDataRecorder gets the data recorder
 func GetDataRecorder() DataRecorder {
 	singletonDataRecorderOnce.Do(func() {

--- a/pkg/handler/data_recorder_datar.go
+++ b/pkg/handler/data_recorder_datar.go
@@ -19,7 +19,7 @@ type datarRecorder struct {
 }
 
 func (d *datarRecorder) AsyncRecord(r models.EvalResult) {
-	if r.RecordSource == models.EvalResultRecordSourceExposure {
+	if !recordCountsTowardDatar(r) {
 		return
 	}
 	d.engine.Record(r.FlagID, r.VariantID, r.SegmentID)

--- a/pkg/handler/data_recorder_kafka.go
+++ b/pkg/handler/data_recorder_kafka.go
@@ -145,7 +145,7 @@ func (k *kafkaRecorder) AsyncRecord(r models.EvalResult) {
 		logrus.WithField("err", err).Error("failed to generate data record frame for kafka recorder")
 		return
 	}
-	var partitionKey sarama.Encoder = nil
+	var partitionKey sarama.Encoder
 	if k.partitionKeyEnabled {
 		partitionKey = sarama.StringEncoder(frame.GetPartitionKey())
 	}

--- a/pkg/handler/data_recorder_kafka.go
+++ b/pkg/handler/data_recorder_kafka.go
@@ -160,7 +160,7 @@ func (k *kafkaRecorder) AsyncRecord(r models.EvalResult) {
 }
 
 var logKafkaAsyncRecordToDatadog = func(r models.EvalResult) {
-	if config.Global.StatsdClient == nil || r.RecordSource == models.EvalResultRecordSourceExposure {
+	if config.Global.StatsdClient == nil || !recordCountsTowardEvalKafkaStatsd(r) {
 		return
 	}
 	config.Global.StatsdClient.Incr(

--- a/pkg/handler/data_recorder_pubsub_test.go
+++ b/pkg/handler/data_recorder_pubsub_test.go
@@ -17,7 +17,7 @@ import (
 func TestNewPubsubRecorder(t *testing.T) {
 	t.Run("no panics", func(t *testing.T) {
 		client := mockClient(t)
-		defer client.Close()
+		t.Cleanup(func() { _ = client.Close() })
 
 		defer gostub.StubFunc(
 			&pubsubClient,
@@ -32,7 +32,7 @@ func TestNewPubsubRecorder(t *testing.T) {
 func TestPubsubAsyncRecord(t *testing.T) {
 	t.Run("enabled and valid", func(t *testing.T) {
 		client := mockClient(t)
-		defer client.Close()
+		t.Cleanup(func() { _ = client.Close() })
 		publisher := client.Publisher("test")
 		assert.NotPanics(t, func() {
 			pr := &pubsubRecorder{
@@ -57,19 +57,18 @@ func TestPubsubAsyncRecord(t *testing.T) {
 }
 
 func mockClient(t *testing.T) *pubsub.Client {
+	t.Helper()
 	ctx := context.Background()
 	srv := pstest.NewServer()
-	defer srv.Close()
+	t.Cleanup(func() { _ = srv.Close() })
 	conn, err := grpc.NewClient(srv.Addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		t.Fatal("cannot connect to mocked server")
 	}
-	defer conn.Close()
+	t.Cleanup(func() { _ = conn.Close() })
 	client, err := pubsub.NewClient(ctx, "project", option.WithGRPCConn(conn))
-
 	if err != nil {
 		t.Fatal("failed creating mock client", err)
 	}
-
 	return client
 }

--- a/pkg/handler/data_recorder_test.go
+++ b/pkg/handler/data_recorder_test.go
@@ -178,7 +178,7 @@ func TestDatarRecorder_AsyncRecord(t *testing.T) {
 
 	db := entity.NewTestDB()
 	defer gostub.StubFunc(&getDB, db).Reset()
-	db.AutoMigrate(entity.AutoMigrateTables...)
+	assert.NoError(t, db.AutoMigrate(entity.AutoMigrateTables...))
 
 	r := NewDatarRecorder()
 	assert.NotNil(t, r)
@@ -201,7 +201,7 @@ func TestDatarRecorder_SkipsExposure(t *testing.T) {
 
 	db := entity.NewTestDB()
 	defer gostub.StubFunc(&getDB, db).Reset()
-	db.AutoMigrate(entity.AutoMigrateTables...)
+	assert.NoError(t, db.AutoMigrate(entity.AutoMigrateTables...))
 
 	_ = GetDatar()
 	r := NewDatarRecorder()
@@ -225,7 +225,7 @@ func TestDatarRecorder_RecordsEvaluationSource(t *testing.T) {
 
 	db := entity.NewTestDB()
 	defer gostub.StubFunc(&getDB, db).Reset()
-	db.AutoMigrate(entity.AutoMigrateTables...)
+	assert.NoError(t, db.AutoMigrate(entity.AutoMigrateTables...))
 
 	r := NewDatarRecorder()
 	r.AsyncRecord(models.EvalResult{

--- a/pkg/handler/data_recorder_test.go
+++ b/pkg/handler/data_recorder_test.go
@@ -94,6 +94,24 @@ func TestDataRecordEnabled(t *testing.T) {
 	assert.False(t, dataRecordEnabled(f))
 }
 
+func TestRecordCountsTowardDatar(t *testing.T) {
+	assert.True(t, recordCountsTowardDatar(models.EvalResult{
+		RecordSource: models.EvalResultRecordSourceEvaluation,
+	}))
+	assert.False(t, recordCountsTowardDatar(models.EvalResult{
+		RecordSource: models.EvalResultRecordSourceExposure,
+	}))
+}
+
+func TestRecordCountsTowardEvalKafkaStatsd(t *testing.T) {
+	assert.True(t, recordCountsTowardEvalKafkaStatsd(models.EvalResult{
+		RecordSource: models.EvalResultRecordSourceEvaluation,
+	}))
+	assert.False(t, recordCountsTowardEvalKafkaStatsd(models.EvalResult{
+		RecordSource: models.EvalResultRecordSourceExposure,
+	}))
+}
+
 func TestFanOutRecorder_Single(t *testing.T) {
 	m := &mockRecorder{}
 	f := fanOutRecorder{m}

--- a/pkg/handler/datar_handler.go
+++ b/pkg/handler/datar_handler.go
@@ -65,10 +65,10 @@ func datarError(msg string, args ...interface{}) *models.Error {
 	return &models.Error{Message: &m}
 }
 
-func parseTimeRange(from, to *strfmt.DateTime, defaultDays int) (time.Time, time.Time) {
+func parseTimeRange(from, to *strfmt.DateTime) (time.Time, time.Time) {
 	now := time.Now().UTC()
 	end := now
-	start := now.Add(-time.Duration(defaultDays) * 24 * time.Hour)
+	start := now.Add(-time.Duration(defaultLookbackDays) * 24 * time.Hour)
 	if from != nil {
 		start = time.Time(*from).UTC()
 	}
@@ -121,7 +121,7 @@ func HandleGetDatarSummary(params datarapi.GetDatarSummaryParams) middleware.Res
 }
 
 func respondDatarSummary(d *datar.Engine, params datarapi.GetDatarSummaryParams) middleware.Responder {
-	from, to := parseTimeRange(params.From, params.To, defaultLookbackDays)
+	from, to := parseTimeRange(params.From, params.To)
 
 	limit := 100
 	if params.Limit != nil {
@@ -162,7 +162,7 @@ func HandleGetDatarFlagSummary(params datarapi.GetDatarFlagSummaryParams) middle
 }
 
 func respondDatarFlagSummary(d *datar.Engine, params datarapi.GetDatarFlagSummaryParams) middleware.Responder {
-	from, to := parseTimeRange(params.From, params.To, defaultLookbackDays)
+	from, to := parseTimeRange(params.From, params.To)
 
 	summary, err := d.QueryFlagSummaryBreakdown(params.FlagID, from, to)
 	if err != nil {

--- a/pkg/handler/datar_test.go
+++ b/pkg/handler/datar_test.go
@@ -20,12 +20,12 @@ func TestParseTimeRange(t *testing.T) {
 	to := strfmt.DateTime(time.Date(2024, 1, 10, 0, 0, 0, 0, time.UTC))
 
 	// Both nil → uses defaults.
-	s, e := parseTimeRange(nil, nil, 7)
+	s, e := parseTimeRange(nil, nil)
 	assert.WithinDuration(t, time.Now().UTC(), e, time.Second)
 	assert.WithinDuration(t, time.Now().UTC().Add(-7*24*time.Hour), s, time.Second)
 
 	// With explicit from/to.
-	s, e = parseTimeRange(&from, &to, 7)
+	s, e = parseTimeRange(&from, &to)
 	assert.Equal(t, time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC), s)
 	assert.Equal(t, time.Date(2024, 1, 10, 0, 0, 0, 0, time.UTC), e)
 }

--- a/pkg/handler/eval_test.go
+++ b/pkg/handler/eval_test.go
@@ -783,7 +783,7 @@ func TestPostEvaluationBatch(t *testing.T) {
 	t.Run("test duplicate flagKeys are deduplicated", func(t *testing.T) {
 		evalCount := 0
 		originalEvalFlag := EvalFlag
-		EvalFlag = func(evalContext models.EvalContext) *models.EvalResult {
+		EvalFlag = func(_ models.EvalContext) *models.EvalResult {
 			evalCount++
 			return &models.EvalResult{}
 		}
@@ -816,7 +816,7 @@ func TestPostEvaluationBatch(t *testing.T) {
 	t.Run("test duplicate flagIDs are deduplicated", func(t *testing.T) {
 		evalCount := 0
 		originalEvalFlag := EvalFlag
-		EvalFlag = func(evalContext models.EvalContext) *models.EvalResult {
+		EvalFlag = func(_ models.EvalContext) *models.EvalResult {
 			evalCount++
 			return &models.EvalResult{}
 		}
@@ -849,7 +849,7 @@ func TestPostEvaluationBatch(t *testing.T) {
 	t.Run("test mixed duplicates are deduplicated", func(t *testing.T) {
 		evalCount := 0
 		originalEvalFlag := EvalFlag
-		EvalFlag = func(evalContext models.EvalContext) *models.EvalResult {
+		EvalFlag = func(_ models.EvalContext) *models.EvalResult {
 			evalCount++
 			return &models.EvalResult{}
 		}
@@ -1114,7 +1114,8 @@ func BenchmarkPostEvaluationBatch(b *testing.B) {
 }
 
 // genBenchmarkEvalCacheWithConstraints creates a flag with multiple constraints for targeted benchmarks.
-func genBenchmarkEvalCacheWithConstraints(constraints []entity.Constraint, numFlags int) *EvalCache {
+func genBenchmarkEvalCacheWithConstraints(constraints []entity.Constraint) *EvalCache {
+	const numFlags = 1
 	idCache := make(map[string]*entity.Flag, numFlags)
 	keyCache := make(map[string]*entity.Flag, numFlags)
 
@@ -1226,7 +1227,7 @@ func BenchmarkEvalFlag_ShortCircuit(b *testing.B) {
 		{Model: gorm.Model{ID: 603}, SegmentID: 301, Property: "country", Operator: models.ConstraintOperatorEQ, Value: `"US"`},
 		{Model: gorm.Model{ID: 604}, SegmentID: 301, Property: "active", Operator: models.ConstraintOperatorEQ, Value: `"true"`},
 	}
-	evalCache := genBenchmarkEvalCacheWithConstraints(constraints, 1)
+	evalCache := genBenchmarkEvalCacheWithConstraints(constraints)
 	defer gostub.StubFunc(&GetEvalCache, evalCache).Reset()
 
 	b.StartTimer()
@@ -1253,7 +1254,7 @@ func BenchmarkEvalFlag_AllMatch(b *testing.B) {
 		{Model: gorm.Model{ID: 703}, SegmentID: 302, Property: "country", Operator: models.ConstraintOperatorEQ, Value: `"US"`},
 		{Model: gorm.Model{ID: 704}, SegmentID: 302, Property: "active", Operator: models.ConstraintOperatorEQ, Value: `"true"`},
 	}
-	evalCache := genBenchmarkEvalCacheWithConstraints(constraints, 1)
+	evalCache := genBenchmarkEvalCacheWithConstraints(constraints)
 	defer gostub.StubFunc(&GetEvalCache, evalCache).Reset()
 
 	b.StartTimer()
@@ -1282,7 +1283,7 @@ func BenchmarkEvalFlag_Regex(b *testing.B) {
 	constraints := []entity.Constraint{
 		{Model: gorm.Model{ID: 800}, SegmentID: 303, Property: "status", Operator: models.ConstraintOperatorEREG, Value: `"/^5[0-9][0-9]$/"`},
 	}
-	evalCache := genBenchmarkEvalCacheWithConstraints(constraints, 1)
+	evalCache := genBenchmarkEvalCacheWithConstraints(constraints)
 	defer gostub.StubFunc(&GetEvalCache, evalCache).Reset()
 
 	b.StartTimer()
@@ -1309,7 +1310,7 @@ func BenchmarkEvalFlag_Complex(b *testing.B) {
 		{Model: gorm.Model{ID: 903}, SegmentID: 304, Property: "email", Operator: models.ConstraintOperatorCONTAINS, Value: `"@company.com"`},
 		{Model: gorm.Model{ID: 904}, SegmentID: 304, Property: "status", Operator: models.ConstraintOperatorNEQ, Value: `"banned"`},
 	}
-	evalCache := genBenchmarkEvalCacheWithConstraints(constraints, 1)
+	evalCache := genBenchmarkEvalCacheWithConstraints(constraints)
 	defer gostub.StubFunc(&GetEvalCache, evalCache).Reset()
 
 	b.StartTimer()

--- a/pkg/handler/exposure.go
+++ b/pkg/handler/exposure.go
@@ -103,7 +103,7 @@ func buildExposureDataRecord(row *models.Exposure) (models.EvalResult, *entity.F
 		ts = time.Time(row.Timestamp).UTC().Format(time.RFC3339)
 	}
 
-	entityCtx := map[string]interface{}{}
+	entityCtx := map[string]any{}
 	mergeJSONIntoMap(entityCtx, row.EntityContext)
 	mergeJSONIntoMap(entityCtx, row.Metadata)
 	var merged any
@@ -165,17 +165,18 @@ func resolveExposureVariant(flag *entity.Flag, variantID int64, variantKey strin
 		return 0, "", nil
 	}
 
-	if variantID > 0 && variantKey != "" {
-		var byID, byKey *entity.Variant
-		for i := range flag.Variants {
-			v := &flag.Variants[i]
-			if v.ID == uint(variantID) {
-				byID = v
-			}
-			if v.Key == variantKey {
-				byKey = v
-			}
+	var byID, byKey *entity.Variant
+	for i := range flag.Variants {
+		v := &flag.Variants[i]
+		if variantID > 0 && v.ID == uint(variantID) {
+			byID = v
 		}
+		if variantKey != "" && v.Key == variantKey {
+			byKey = v
+		}
+	}
+
+	if variantID > 0 && variantKey != "" {
 		if byID == nil {
 			return 0, "", fmt.Errorf("variantID %d not found on flag", variantID)
 		}
@@ -189,23 +190,21 @@ func resolveExposureVariant(flag *entity.Flag, variantID int64, variantKey strin
 	}
 
 	if variantID > 0 {
-		for _, v := range flag.Variants {
-			if v.ID == uint(variantID) {
-				return int64(v.ID), v.Key, nil
-			}
+		if byID == nil {
+			return 0, "", fmt.Errorf("variantID %d not found on flag", variantID)
 		}
-		return 0, "", fmt.Errorf("variantID %d not found on flag", variantID)
+		return int64(byID.ID), byID.Key, nil
 	}
 
-	for _, v := range flag.Variants {
-		if v.Key == variantKey {
-			return int64(v.ID), v.Key, nil
-		}
+	if byKey == nil {
+		return 0, "", fmt.Errorf("variantKey %q not found on flag", variantKey)
 	}
-	return 0, "", fmt.Errorf("variantKey %q not found on flag", variantKey)
+	return int64(byKey.ID), byKey.Key, nil
 }
 
-func mergeJSONIntoMap(dst map[string]interface{}, src any) {
+// mergeJSONIntoMap copies top-level keys from arbitrary client JSON (swagger any)
+// into dst. Non-objects, null, and empty objects are intentionally ignored.
+func mergeJSONIntoMap(dst map[string]any, src any) {
 	if src == nil {
 		return
 	}
@@ -213,7 +212,7 @@ func mergeJSONIntoMap(dst map[string]interface{}, src any) {
 	if err != nil || len(b) == 0 || string(b) == "null" {
 		return
 	}
-	var m map[string]interface{}
+	var m map[string]any
 	if err := json.Unmarshal(b, &m); err != nil || len(m) == 0 {
 		return
 	}

--- a/pkg/handler/exposure.go
+++ b/pkg/handler/exposure.go
@@ -31,9 +31,9 @@ func (h *exposureHandler) PostExposures(params exposureapi.PostExposuresParams) 
 	}
 
 	exposures := params.Body.Exposures
-	if max := config.Config.ExposureBatchSize; max > 0 && len(exposures) > max {
+	if batchMax := config.Config.ExposureBatchSize; batchMax > 0 && len(exposures) > batchMax {
 		return exposureapi.NewPostExposuresDefault(400).WithPayload(
-			ErrorMessage("exposure batch size %d exceeds maximum allowed size of %d", len(exposures), max))
+			ErrorMessage("exposure batch size %d exceeds maximum allowed size of %d", len(exposures), batchMax))
 	}
 
 	var logged int64
@@ -236,5 +236,5 @@ var logExposureStatsd = func(status string, flagID int64, flagKey string) {
 	if status == "recorded" {
 		metric = "exposure.recorded"
 	}
-	config.Global.StatsdClient.Incr(metric, tags, 1)
+	_ = config.Global.StatsdClient.Incr(metric, tags, 1)
 }

--- a/pkg/handler/exposure.go
+++ b/pkg/handler/exposure.go
@@ -1,7 +1,6 @@
 package handler
 
 import (
-	"encoding/json"
 	"fmt"
 	"time"
 
@@ -103,18 +102,15 @@ func buildExposureDataRecord(row *models.Exposure) (models.EvalResult, *entity.F
 		ts = time.Time(row.Timestamp).UTC().Format(time.RFC3339)
 	}
 
-	entityCtx := map[string]any{}
-	mergeJSONIntoMap(entityCtx, row.EntityContext)
-	mergeJSONIntoMap(entityCtx, row.Metadata)
-	var merged any
-	if len(entityCtx) > 0 {
-		merged = entityCtx
+	var entityContext any
+	if row.EntityContext != nil {
+		entityContext = row.EntityContext
 	}
 
 	evalCtx := models.EvalContext{
 		EntityID:      *row.EntityID,
 		EntityType:    entityType,
-		EntityContext: merged,
+		EntityContext: entityContext,
 	}
 
 	return models.EvalResult{
@@ -200,25 +196,6 @@ func resolveExposureVariant(flag *entity.Flag, variantID int64, variantKey strin
 		return 0, "", fmt.Errorf("variantKey %q not found on flag", variantKey)
 	}
 	return int64(byKey.ID), byKey.Key, nil
-}
-
-// mergeJSONIntoMap copies top-level keys from arbitrary client JSON (swagger any)
-// into dst. Non-objects, null, and empty objects are intentionally ignored.
-func mergeJSONIntoMap(dst map[string]any, src any) {
-	if src == nil {
-		return
-	}
-	b, err := json.Marshal(src)
-	if err != nil || len(b) == 0 || string(b) == "null" {
-		return
-	}
-	var m map[string]any
-	if err := json.Unmarshal(b, &m); err != nil || len(m) == 0 {
-		return
-	}
-	for k, v := range m {
-		dst[k] = v
-	}
 }
 
 var logExposureStatsd = func(status string, flagID int64, flagKey string) {

--- a/pkg/handler/exposure_test.go
+++ b/pkg/handler/exposure_test.go
@@ -340,12 +340,11 @@ func TestBuildExposureDataRecord(t *testing.T) {
 		assert.Equal(t, "from_flag", r.EvalContext.EntityType)
 	})
 
-	t.Run("merges entityContext and metadata", func(t *testing.T) {
+	t.Run("entityContext on record", func(t *testing.T) {
 		r, _, err := buildExposureDataRecord(&models.Exposure{
-			EntityID:       &eid,
-			FlagID:         int64(fixture.ID),
-			EntityContext:  map[string]any{"country": "US"},
-			Metadata:       map[string]interface{}{"page": "/home"},
+			EntityID:      &eid,
+			FlagID:        int64(fixture.ID),
+			EntityContext: map[string]any{"country": "US", "page": "/home"},
 		})
 		if !assert.NoError(t, err) {
 			return
@@ -468,18 +467,6 @@ func TestResolveExposureFlag(t *testing.T) {
 	})
 }
 
-func TestMergeJSONIntoMap(t *testing.T) {
-	dst := map[string]any{}
-	mergeJSONIntoMap(dst, map[string]any{"a": 1})
-	mergeJSONIntoMap(dst, map[string]any{"b": 2})
-	assert.Equal(t, float64(1), dst["a"])
-	assert.Equal(t, float64(2), dst["b"])
-
-	mergeJSONIntoMap(dst, nil)
-	mergeJSONIntoMap(dst, "not-json-object")
-	mergeJSONIntoMap(dst, map[string]any{})
-	assert.Len(t, dst, 2)
-}
 
 func TestLogExposureStatsd_Stubbed(t *testing.T) {
 	var lastStatus string

--- a/pkg/handler/exposure_test.go
+++ b/pkg/handler/exposure_test.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"encoding/json"
 	"fmt"
 	"testing"
 	"time"
@@ -153,6 +154,59 @@ func TestPostExposures_RecordsWhenEnabled(t *testing.T) {
 	}
 }
 
+func TestExposureEvalResult_WireContainsRecordSource(t *testing.T) {
+	defer gostub.StubFunc(&GetEvalCache, GenFixtureEvalCache()).Reset()
+	eid := "wire-test-entity"
+	r, _, err := buildExposureDataRecord(&models.Exposure{
+		EntityID: &eid,
+		FlagID:   100,
+	})
+	if !assert.NoError(t, err) {
+		return
+	}
+	raw, err := r.MarshalBinary()
+	if !assert.NoError(t, err) {
+		return
+	}
+	var payload map[string]any
+	if !assert.NoError(t, json.Unmarshal(raw, &payload)) {
+		return
+	}
+	assert.Equal(t, models.EvalResultRecordSourceExposure, payload["recordSource"])
+	assert.Equal(t, int64(0), r.SegmentID)
+}
+
+func TestExposureDataRecordFrame_OutputContainsRecordSource(t *testing.T) {
+	defer gostub.StubFunc(&GetEvalCache, GenFixtureEvalCache()).Reset()
+	eid := "frame-test-entity"
+	r, _, err := buildExposureDataRecord(&models.Exposure{
+		EntityID: &eid,
+		FlagID:   100,
+	})
+	if !assert.NoError(t, err) {
+		return
+	}
+	frame := DataRecordFrame{
+		evalResult: r,
+		options:    DataRecordFrameOptions{FrameOutputMode: frameOutputModePayloadRawJSON},
+	}
+	out, err := frame.Output()
+	if !assert.NoError(t, err) {
+		return
+	}
+	var outer struct {
+		Payload json.RawMessage `json:"payload"`
+	}
+	if !assert.NoError(t, json.Unmarshal(out, &outer)) {
+		return
+	}
+	var inner map[string]any
+	if !assert.NoError(t, json.Unmarshal(outer.Payload, &inner)) {
+		return
+	}
+	assert.Equal(t, models.EvalResultRecordSourceExposure, inner["recordSource"])
+}
+
 func TestBuildExposureDataRecord(t *testing.T) {
 	defer gostub.StubFunc(&GetEvalCache, GenFixtureEvalCache()).Reset()
 	fixture := entity.GenFixtureFlag()
@@ -296,7 +350,7 @@ func TestBuildExposureDataRecord(t *testing.T) {
 		if !assert.NoError(t, err) {
 			return
 		}
-		ctx, ok := r.EvalContext.EntityContext.(map[string]interface{})
+		ctx, ok := r.EvalContext.EntityContext.(map[string]any)
 		if !assert.True(t, ok) {
 			return
 		}
@@ -415,9 +469,9 @@ func TestResolveExposureFlag(t *testing.T) {
 }
 
 func TestMergeJSONIntoMap(t *testing.T) {
-	dst := map[string]interface{}{}
+	dst := map[string]any{}
 	mergeJSONIntoMap(dst, map[string]any{"a": 1})
-	mergeJSONIntoMap(dst, map[string]interface{}{"b": 2})
+	mergeJSONIntoMap(dst, map[string]any{"b": 2})
 	assert.Equal(t, float64(1), dst["a"])
 	assert.Equal(t, float64(2), dst["b"])
 

--- a/swagger/index.yaml
+++ b/swagger/index.yaml
@@ -660,15 +660,13 @@ definitions:
       entityContext:
         type: object
         additionalProperties: true
+        description: Optional attributes recorded on evalContext.entityContext (same field as POST /evaluation). Include impression-specific keys here (e.g. page path); exposure does not re-run segment constraints.
       flagSnapshotID:
         type: integer
         format: int64
       timestamp:
         type: string
         format: date-time
-      metadata:
-        type: object
-        additionalProperties: true
   exposuresResponse:
     type: object
     properties:

--- a/swagger/index.yaml
+++ b/swagger/index.yaml
@@ -210,7 +210,6 @@ definitions:
   flagSnapshot:
     type: object
     required:
-      - id
       - flag
       - updatedAt
     properties:

--- a/swagger/index.yaml
+++ b/swagger/index.yaml
@@ -145,7 +145,7 @@ definitions:
         items:
           $ref: "#/definitions/variant"
       dataRecordsEnabled:
-        description: enabled data records will get data logging in the metrics pipeline, for example, kafka.
+        description: when true and FLAGR_RECORDER_ENABLED is set, evaluation and exposure rows are written to configured data recorders (e.g. kafka).
         type: boolean
       entityType:
         description: it will override the entityType in the evaluation logs if it's not empty
@@ -183,7 +183,7 @@ definitions:
         x-nullable: true
       dataRecordsEnabled:
         type: boolean
-        description: enabled data records will get data logging in the metrics pipeline, for example, kafka.
+        description: when true and FLAGR_RECORDER_ENABLED is set, evaluation and exposure rows are written to configured data recorders (e.g. kafka).
         x-nullable: true
       entityType:
         description: it will overwrite entityType into evaluation logs if it's not empty

--- a/swagger_gen/models/eval_result.go
+++ b/swagger_gen/models/eval_result.go
@@ -37,7 +37,7 @@ type EvalResult struct {
 	// flagTags. flagTags looks up flags by tag. Either works.
 	FlagTags []string `json:"flagTags,omitempty"`
 
-	// evaluation for eval API results; exposure for POST /exposures pipeline events
+	// evaluation for eval API results; exposure for client-reported impressions via POST /exposures (same data recorders as eval)
 	// Enum: ["evaluation","exposure"]
 	RecordSource string `json:"recordSource,omitempty"`
 

--- a/swagger_gen/models/exposure.go
+++ b/swagger_gen/models/exposure.go
@@ -17,7 +17,7 @@ import (
 // swagger:model exposure
 type Exposure struct {
 
-	// entity context
+	// Optional attributes recorded on evalContext.entityContext (same field as POST /evaluation). Include impression-specific keys here (e.g. page path); exposure does not re-run segment constraints.
 	EntityContext any `json:"entityContext,omitempty"`
 
 	// entity ID
@@ -35,9 +35,6 @@ type Exposure struct {
 
 	// flag snapshot ID
 	FlagSnapshotID int64 `json:"flagSnapshotID,omitempty"`
-
-	// metadata
-	Metadata any `json:"metadata,omitempty"`
 
 	// timestamp
 	// Format: date-time

--- a/swagger_gen/models/flag.go
+++ b/swagger_gen/models/flag.go
@@ -22,7 +22,7 @@ type Flag struct {
 	// created by
 	CreatedBy string `json:"createdBy,omitempty"`
 
-	// enabled data records will get data logging in the metrics pipeline, for example, kafka.
+	// when true and FLAGR_RECORDER_ENABLED is set, evaluation and exposure rows are written to configured data recorders (e.g. kafka).
 	// Required: true
 	DataRecordsEnabled *bool `json:"dataRecordsEnabled"`
 

--- a/swagger_gen/models/flag_snapshot.go
+++ b/swagger_gen/models/flag_snapshot.go
@@ -9,6 +9,7 @@ import (
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag/jsonutils"
+	"github.com/go-openapi/swag/typeutils"
 	"github.com/go-openapi/validate"
 )
 
@@ -22,10 +23,9 @@ type FlagSnapshot struct {
 	Flag *Flag `json:"flag"`
 
 	// id
-	// Required: true
 	// Read Only: true
 	// Minimum: 1
-	ID int64 `json:"id"`
+	ID int64 `json:"id,omitempty"`
 
 	// updated at
 	// Required: true
@@ -83,9 +83,8 @@ func (m *FlagSnapshot) validateFlag(formats strfmt.Registry) error {
 }
 
 func (m *FlagSnapshot) validateID(formats strfmt.Registry) error {
-
-	if err := validate.Required("id", "body", m.ID); err != nil {
-		return err
+	if typeutils.IsZero(m.ID) { // not required
+		return nil
 	}
 
 	if err := validate.MinimumInt("id", "body", m.ID, 1, false); err != nil {

--- a/swagger_gen/models/put_flag_request.go
+++ b/swagger_gen/models/put_flag_request.go
@@ -17,7 +17,7 @@ import (
 // swagger:model putFlagRequest
 type PutFlagRequest struct {
 
-	// enabled data records will get data logging in the metrics pipeline, for example, kafka.
+	// when true and FLAGR_RECORDER_ENABLED is set, evaluation and exposure rows are written to configured data recorders (e.g. kafka).
 	DataRecordsEnabled *bool `json:"dataRecordsEnabled,omitempty"`
 
 	// description

--- a/swagger_gen/restapi/embedded_spec.go
+++ b/swagger_gen/restapi/embedded_spec.go
@@ -1914,7 +1914,7 @@ func init() {
           "x-omitempty": true
         },
         "recordSource": {
-          "description": "evaluation for eval API results; exposure for POST /exposures pipeline events",
+          "description": "evaluation for eval API results; exposure for client-reported impressions via POST /exposures (same data recorders as eval)",
           "type": "string",
           "enum": [
             "evaluation",
@@ -2030,6 +2030,7 @@ func init() {
       ],
       "properties": {
         "entityContext": {
+          "description": "Optional attributes recorded on evalContext.entityContext (same field as POST /evaluation). Include impression-specific keys here (e.g. page path); exposure does not re-run segment constraints.",
           "type": "object",
           "additionalProperties": true
         },
@@ -2049,10 +2050,6 @@ func init() {
         "flagSnapshotID": {
           "type": "integer",
           "format": "int64"
-        },
-        "metadata": {
-          "type": "object",
-          "additionalProperties": true
         },
         "timestamp": {
           "type": "string",
@@ -2124,7 +2121,7 @@ func init() {
           "type": "string"
         },
         "dataRecordsEnabled": {
-          "description": "enabled data records will get data logging in the metrics pipeline, for example, kafka.",
+          "description": "when true and FLAGR_RECORDER_ENABLED is set, evaluation and exposure rows are written to configured data recorders (e.g. kafka).",
           "type": "boolean"
         },
         "description": {
@@ -2241,7 +2238,7 @@ func init() {
       "type": "object",
       "properties": {
         "dataRecordsEnabled": {
-          "description": "enabled data records will get data logging in the metrics pipeline, for example, kafka.",
+          "description": "when true and FLAGR_RECORDER_ENABLED is set, evaluation and exposure rows are written to configured data recorders (e.g. kafka).",
           "type": "boolean",
           "x-nullable": true
         },
@@ -4403,7 +4400,7 @@ func init() {
           "x-omitempty": true
         },
         "recordSource": {
-          "description": "evaluation for eval API results; exposure for POST /exposures pipeline events",
+          "description": "evaluation for eval API results; exposure for client-reported impressions via POST /exposures (same data recorders as eval)",
           "type": "string",
           "enum": [
             "evaluation",
@@ -4519,6 +4516,7 @@ func init() {
       ],
       "properties": {
         "entityContext": {
+          "description": "Optional attributes recorded on evalContext.entityContext (same field as POST /evaluation). Include impression-specific keys here (e.g. page path); exposure does not re-run segment constraints.",
           "type": "object",
           "additionalProperties": true
         },
@@ -4538,10 +4536,6 @@ func init() {
         "flagSnapshotID": {
           "type": "integer",
           "format": "int64"
-        },
-        "metadata": {
-          "type": "object",
-          "additionalProperties": true
         },
         "timestamp": {
           "type": "string",
@@ -4613,7 +4607,7 @@ func init() {
           "type": "string"
         },
         "dataRecordsEnabled": {
-          "description": "enabled data records will get data logging in the metrics pipeline, for example, kafka.",
+          "description": "when true and FLAGR_RECORDER_ENABLED is set, evaluation and exposure rows are written to configured data recorders (e.g. kafka).",
           "type": "boolean"
         },
         "description": {
@@ -4730,7 +4724,7 @@ func init() {
       "type": "object",
       "properties": {
         "dataRecordsEnabled": {
-          "description": "enabled data records will get data logging in the metrics pipeline, for example, kafka.",
+          "description": "when true and FLAGR_RECORDER_ENABLED is set, evaluation and exposure rows are written to configured data recorders (e.g. kafka).",
           "type": "boolean",
           "x-nullable": true
         },

--- a/swagger_gen/restapi/embedded_spec.go
+++ b/swagger_gen/restapi/embedded_spec.go
@@ -2180,7 +2180,6 @@ func init() {
     "flagSnapshot": {
       "type": "object",
       "required": [
-        "id",
         "flag",
         "updatedAt"
       ],
@@ -4666,7 +4665,6 @@ func init() {
     "flagSnapshot": {
       "type": "object",
       "required": [
-        "id",
         "flag",
         "updatedAt"
       ],


### PR DESCRIPTION
Follow-up to #711 (exposure logging on `main`).

## What this PR does

1. **Docs** — [Data Recorders & A/B Analysis](docs/flagr_eval_exposure_pipeline.md): eval vs exposure, recorders (Kafka/Kinesis/Pub/Sub/Datar), sample consumer, A/B notes. Sidebar and cross-links updated.

2. **Exposure API simplification** — Removed `metadata` on exposure rows. Clients use **`entityContext` only** (same as `POST /evaluation`). Impression fields like `page` go in that one object.

3. **Integration** — Stronger `TestIntegration_Exposures` (recorder on auto-start, `loggedCount`).

4. **Developer ergonomics** — `.golangci.yml` (v2, `integration` build tags for IDE). Handler lint/test tidy (gostub `getDB`, etc.).

5. **Swagger** — `flagSnapshot`: drop `id` from `required` (fixes required+readOnly warning on `make gen`).

## Testing

- `make test` (lint + unit tests)

## Breaking?

- **Exposure clients** that sent `metadata` must move those keys into **`entityContext`**. No separate `metadata` field in the API anymore.

Related: #711