### PR TITLE
docs: refactor and enrich all docs for clarity, accuracy, and narrative

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,14 +8,14 @@ Flagr — Go feature flag service with Vue 3 UI.
 |---|---|
 | `make build` | Build Go server binary (`./flagr`) |
 | `make build_ui` | Build UI for production (`browser/flagr-ui/dist/`) |
-| `make start` | Run backend (`:18000`) + frontend dev server (`:8080`) in parallel |
-| `make stop-ui` | Kill processes on `:18000` or `:8080` (port-based, not `pkill`) |
+| `make start` | Backend (`:18000`) + frontend dev server (`:8080`) in parallel |
+| `make stop-ui` | Kill processes on `:18000` or `:8080` (port-based via `lsof`, not `pkill`) |
 | `make rebuild-run` | `build` → `stop-ui` → `start` — one step after Go changes |
 | `make test` | Go unit tests |
-| `make test-e2e` | Build Go binary → start servers via `scripts/e2e-server.sh` → Playwright → cleanup |
+| `make test-e2e` | Build Go binary → start servers → Playwright → cleanup |
 | `make swagger` | Regenerate `swagger_gen/` from OpenAPI spec |
-| `make test-integration` | Run Go integration tests (auto-starts local server, SQLite) |
-| `make bench-integration` | Run HTTP eval benchmarks against local server |
+| `make test-integration` | Go integration tests (auto-starts local server, SQLite `:memory:`) |
+| `make bench-integration` | HTTP eval benchmarks against local server |
 | `go build -o flagr-validate ./cmd/flagr-validate/` | Build standalone JSON flag validator |
 | `go build -o flagr ./cmd/flagr-server/` | Build server binary directly (same as `make build`) |
 
@@ -23,42 +23,21 @@ Flagr — Go feature flag service with Vue 3 UI.
 
 ## Key Code
 
-### Backend (`pkg/`)
-- `handler/crud.go` — CRUD API handlers, `handler/eval.go` — evaluation engine
+**Backend (`pkg/`):**
+- `handler/eval.go` — evaluation engine; `handler/crud.go` — CRUD API handlers
+- `handler/exposure.go` — exposure (impression) logging; `handler/data_recorder*.go` — recorders (Kafka, Kinesis, Pub/Sub, Datar)
 - `entity/` — domain models (flag, segment, constraint, variant, distribution)
-- `mapper/entity_restapi/` — conversions between entities and API models
+- `config/env.go` — all environment variables (single source of truth)
 
-### Frontend (`browser/flagr-ui/src/`)
-- `components/Flag.vue` — flag detail page (orchestrates sub-components)
-- `components/Flags.vue` — flag list page with search/filter
-- `components/FlagConfigCard.vue` — flag key/description/tags/notes editor
-- `components/VariantsSection.vue` — variant CRUD
-- `components/SegmentsSection.vue` — segment + constraint + distribution display
-- `components/DistributionDialog.vue` — distribution editing modal
-- `components/DebugConsole.vue` — inline eval request/response tool
-- `components/FlagHistory.vue` — snapshot diff viewer
-- `components/MarkdownEditor.vue` — flag notes with markdown + KaTeX
-- `helpers/helpers.js` — utility functions (`pluck`, `sum`, `handleErr`)
-- `constants.js` — env-var-backed config (`VITE_API_URL`, entity types)
-
-## Workflows
-
-**Frontend-only dev:** `npm run dev` in `browser/flagr-ui/` (Vite proxies `/api/v1` to `:18000`).
-
-**Backend changes:** Frontend auto-reloads via Vite HMR. Backend needs rebuild: `make rebuild-run`.
-
-**E2E tests:** `make test-e2e` — single command. Uses `scripts/e2e-server.sh` (idempotent, port-safe) and Playwright's `webServer` lifecycle. Always works regardless of leftover processes.
-
-**Integration tests:** Three modes:
-- **Local** (`make test-integration`): Auto-starts server on random port with SQLite `:memory:`. Run `go test -tags=integration ./integration_tests/` directly.
-- **Docker Compose** (`cd integration_tests && make test`): Builds Go test binary, loops over 6 flagr instances (sqlite, mysql, mysql8, postgres9, postgres13, checkr), runs suite against each.
-- **Benchmarks** (`make bench-integration`): HTTP eval benchmarks against auto-started server.
-
-**Process management** uses `lsof -ti:<port>` not `pkill -f`, so it never touches processes from other projects.
+**Frontend (`browser/flagr-ui/src/`):**
+- `components/Flag.vue` — flag detail page (orchestrator); `components/Flags.vue` — flag list
+- `components/DebugConsole.vue` — inline eval tool; `components/SegmentsSection.vue` — segment/constraint/distribution display
+- `helpers/helpers.js`, `constants.js` — utilities and env-var-backed config
 
 ## Constraints
 
 - **Don't edit `swagger_gen/`** — regenerate with `make swagger`
 - Dev mode uses SQLite, no external deps needed
+- Process management uses `lsof -ti:<port>` not `pkill -f` — never touches other projects' processes
 - See [deepwiki.com/openflagr/flagr](https://deepwiki.com/openflagr/flagr) and `docs/`
-- When create PR, follow the PULL_REQUEST_TEMPLATE.md
+- When creating a PR, follow `PULL_REQUEST_TEMPLATE.md`

--- a/README.md
+++ b/README.md
@@ -19,11 +19,19 @@
     </a>
 </p>
 
-## Introduction
+## What is Flagr?
 
-Flagr is an open source Go service that delivers the right experience to the right entity and monitors the impact. It provides feature flags, experimentation (A/B testing), and dynamic configuration — all behind clear swagger REST APIs for flag management and evaluation.
+Flagr is an open-source Go service for **feature flags**, **A/B testing**, and
+**dynamic configuration**. One primitive — the *flag* — covers all three: a
+decision point in your code that the evaluation engine resolves at runtime
+based on *who* is asking.
 
-`openflagr/flagr` is the community-driven home of Flagr, advancing development beyond the original [`checkr/flagr`](https://github.com/checkr/flagr).
+It exists to decouple *deploy* from *release* — turn a feature on for one user,
+a thousand, or nobody, without redeploying. Run experiments and trust the
+numbers. Change configuration without a code change or a restart.
+
+`openflagr/flagr` is the community-driven home of Flagr, advancing development
+beyond the original [`checkr/flagr`](https://github.com/checkr/flagr).
 
 ---
 
@@ -49,18 +57,14 @@ Flagr is an open source Go service that delivers the right experience to the rig
 
 ## Features
 
-| Capability | Description |
-|------------|-------------|
-| **Feature flags** | Binary on/off toggles, kill switches, targeted rollouts by audience segment |
-| **A/B testing** | Multi-variant experiments with deterministic distribution and rollout control |
-| **Dynamic configuration** | Per-variant JSON attachments for runtime config without redeploy |
-| **GitOps / Flags-as-code** | Load flags from JSON files or HTTP URLs. Manage flags in Git, validate in CI, rollback with `git revert` |
-| **Datar analytics** | Built-in in-memory aggregate analytics — evaluation counts by variant, segment, and day. No external pipeline required |
-| **Exposure logging** | `POST /exposures` for client-reported impressions; same **data recorders** as eval (`AsyncRecord`), with `recordSource: exposure` |
-| **Webhook notifications** | HTTP POST webhooks on every flag create/update/delete/restore with retry and exponential backoff |
-| **Multi-database** | SQLite (dev), MySQL, PostgreSQL, and JSON sources |
-| **Eval cache** | In-memory cache with short-circuit reload — only refreshes when flag snapshots change |
-| **Vue 3 UI** | Modern management UI built with Vite, Vue 3, and Element Plus |
+- **Feature flags** — binary on/off, kill switches, targeted rollouts by audience
+- **A/B testing** — multi-variant experiments with deterministic, sticky assignment
+- **Dynamic configuration** — per-variant JSON attachments, no redeploy or restart
+- **GitOps / Flags-as-code** — load flags from JSON or HTTP; manage in Git, validate in CI, rollback with `git revert`
+- **Exposure logging** — `POST /exposures` for client-reported impressions, the trustworthy A/B denominator
+- **Webhook notifications** — HTTP POST on every flag change, with retry and backoff
+- **Multi-database** — SQLite (dev), MySQL, PostgreSQL, and JSON sources
+- **Vue 3 UI** — modern management UI built with Vite, Vue 3, and Element Plus
 
 ## Quick start
 
@@ -72,7 +76,9 @@ docker run -it -p 18000:18000 ghcr.io/openflagr/flagr
 open localhost:18000
 ```
 
-Or try the hosted demo at [https://try-flagr.onrender.com](https://try-flagr.onrender.com) (cold starts may take a moment; every push to `main` triggers a redeploy):
+Or try the hosted demo at
+[https://try-flagr.onrender.com](https://try-flagr.onrender.com) (cold starts
+may take a moment):
 
 ```sh
 curl --request POST \
@@ -95,17 +101,23 @@ curl --request POST \
 
 ## Architecture
 
-Flagr has three core components:
+Flagr has three components:
 
-- **Evaluator** — evaluates incoming requests against an in-memory `EvalCache` of all flags, segments, variants, constraints, and distributions. The cache refreshes periodically (default 3s) and short-circuits when no new snapshots exist.
-- **Manager** — CRUD gateway for all flag mutations.
-- **Metrics** — **Data recorders** for evaluation and exposure rows (`GetDataRecorder().AsyncRecord`). Kafka, AWS Kinesis, Google Pub/Sub, and built-in Datar. Exposures skip eval metrics and Datar aggregation.
+- **Evaluator** — serves evaluation from an in-memory cache of all flags. The
+  cache refreshes periodically (default 3s) and short-circuits when nothing
+  changed, so evaluation never touches the database on the request path.
+- **Manager** — the CRUD gateway; all flag mutations flow through here.
+- **Metrics** — fans evaluation and exposure events out to your data pipeline
+  (Kafka, Kinesis, Pub/Sub) or the built-in Datar aggregates. Recording is
+  asynchronous, so a slow backend never stalls an evaluation.
 
-See the [architecture overview](https://openflagr.github.io/flagr/#/flagr_overview) for the full diagram and evaluation algorithm.
+See the [architecture overview](https://openflagr.github.io/flagr/#/flagr_overview)
+for the full diagram and the deterministic bucketing algorithm.
 
 ## Performance
 
-Tested with [`vegeta`](./benchmark) — 2,000 req/s sustained:
+Tested with [`vegeta`](./benchmark) — 2,000 req/s sustained, sub-millisecond
+median latency:
 
 ```
 Requests      [total, rate]            56521, 2000.04
@@ -117,12 +129,12 @@ Status Codes  [code:count]             200:56521
 
 ## Client Libraries
 
-| Language   | Client                                          |
-| ---------- | ----------------------------------------------- |
-| Go         | [goflagr](https://github.com/openflagr/goflagr) |
+| Language | Client |
+| -------- | ------ |
+| Go | [goflagr](https://github.com/openflagr/goflagr) |
 | JavaScript | [jsflagr](https://github.com/openflagr/jsflagr) |
-| Python     | [pyflagr](https://github.com/openflagr/pyflagr) |
-| Ruby       | [rbflagr](https://github.com/openflagr/rbflagr) |
+| Python | [pyflagr](https://github.com/openflagr/pyflagr) |
+| Ruby | [rbflagr](https://github.com/openflagr/rbflagr) |
 
 ## License and Credit
 

--- a/docs/flagr_datar.md
+++ b/docs/flagr_datar.md
@@ -1,23 +1,45 @@
 # Datar Aggregate Analytics
 
-Datar is an optional in-memory aggregate analytics engine built into Flagr. It tallies evaluation counts by flag, variant, segment, and hour, then exposes the results through two REST endpoints — no external pipeline, no Kafka consumer, no separate analytics stack required.
+Not every team that runs feature flags has a data pipeline. Sometimes you
+just want to know: *how many evaluations did this flag get this week, split
+by variant and segment?* Standing up Kafka, a consumer, and a warehouse to
+answer that question is overkill. Datar is the answer for that case — an
+optional in-memory aggregate analytics engine built into Flagr. It tallies
+evaluation counts by flag, variant, segment, and hour, then exposes the
+results through two REST endpoints. No external pipeline, no Kafka consumer,
+no separate analytics stack — just one more entry in `FLAGR_RECORDER_TYPE`.
+
+Datar is an optional in-memory aggregate analytics engine built into Flagr.
+It tallies evaluation counts by flag, variant, segment, and hour, then
+exposes the results through two REST endpoints — no external pipeline, no
+Kafka consumer, no separate analytics stack required.
 
 ## When to use
 
-A simple, zero-dependency solution for trivial aggregate analytics. Use it when you need basic evaluation counts broken down by variant and segment without setting up an external pipeline.
+Datar exists in the gap between "no analytics" and "full pipeline." If you
+already run Kafka and a warehouse, you don't need it — your streaming
+recorders give you richer data. Datar is for the team that wants a quick
+dashboard without standing up infrastructure: basic evaluation counts broken
+down by variant and segment, queryable through a REST endpoint, persisted in
+a single table.
 
-Prometheus covers rate-based metrics and variant-level time-series well, but it cannot index by `segment_id` due to high cardinality. Use Datar when you need:
+Prometheus covers rate-based metrics and variant-level time-series well, but it
+cannot index by `segment_id` due to high cardinality. Use Datar when you need:
 
 - **Segment breakdowns** — how many evaluations each segment received
 - **Historic totals** — cumulative counts (not just rates) over days or weeks
-- **Per-flag dashboards** — a simple summary view across all flags without setting up a separate analytics stack
+- **Per-flag dashboards** — a simple summary view across all flags without a
+  separate analytics stack
 
-For **client-reported impressions** and warehouse-style A/B analysis, use [Exposure Logging](flagr_exposure.md) and [Data Recorders & A/B Analysis](flagr_eval_exposure_pipeline.md) (Kafka, Kinesis, or Pub/Sub). Datar does not ingest exposure rows.
-
+For **client-reported impressions** and warehouse-style A/B analysis, use
+[Exposure Logging](flagr_exposure.md) and
+[Data Recorders & A/B Analysis](flagr_eval_exposure_pipeline.md) (Kafka,
+Kinesis, or Pub/Sub). Datar does not ingest exposure rows.
 
 ## Enabling
 
-Requires `FLAGR_RECORDER_ENABLED=true`. With the master switch on, list `datar` in `RecorderType` to activate the in-memory aggregator:
+Requires `FLAGR_RECORDER_ENABLED=true`. With the master switch on, list
+`datar` in `FLAGR_RECORDER_TYPE` to activate the in-memory aggregator:
 
 ```bash
 export FLAGR_RECORDER_ENABLED=true
@@ -25,26 +47,33 @@ export FLAGR_RECORDER_TYPE=kafka,datar
 export FLAGR_RECORDER_DATAR_FLUSH_INTERVAL=60s    # default
 ```
 
-The `datar_hourly_events` table is created automatically by AutoMigrate on startup. No schema migration is needed.
-
+The `datar_hourly_events` table is created automatically by AutoMigrate on
+startup. No schema migration is needed.
 
 ## Recording
+
 Datar recording is gated on three conditions:
 
 1. `FLAGR_RECORDER_ENABLED=true` (master switch)
-2. Listing `datar` in `FLAGR_RECORDER_TYPE`
-3. The per-flag toggle `dataRecordsEnabled: true` (configurable via `PUT /api/v1/flags/{id}`)
+2. `datar` listed in `FLAGR_RECORDER_TYPE`
+3. The per-flag toggle `dataRecordsEnabled: true`
+   (configurable via `PUT /api/v1/flags/{id}`)
 
+This means you can selectively enable recording per flag, even when Datar is
+globally enabled.
 
-This means you can selectively enable recording per flag, even when Datar is globally enabled.
-
-> **Note:** After creating or updating a flag, wait at least one eval cache refresh cycle (~3s by default) before sending evaluations. The eval cache needs to pick up the new flag's configuration, or evaluations will return "not found" and won't reach the Datar recorder.
+> **Note:** After creating or updating a flag, wait at least one eval cache
+> refresh cycle (~3s by default) before sending evaluations. The eval cache
+> needs to pick up the new flag's configuration, or evaluations will return
+> "not found" and won't reach the Datar recorder.
 
 ## Endpoints
 
 ### GET /api/v1/datar/summary
 
-Returns flags with aggregate totals over a time window. **Only flags that have actual evaluation traffic in the window appear** — zero-traffic flags are excluded.
+Returns flags with aggregate totals over a time window. **Only flags that have
+actual evaluation traffic in the window appear** — zero-traffic flags are
+excluded.
 
 | Param | Type | Default | Description |
 |-------|------|---------|-------------|
@@ -72,7 +101,9 @@ Response:
 
 ### GET /api/v1/datar/flags/{flagID}/summary
 
-Detailed breakdown for a single flag. Returns traffic grouped by variant, segment, and day — all three arrays sorted (descending by count for variant/segment, ascending by date for day).
+Detailed breakdown for a single flag. Returns traffic grouped by variant,
+segment, and day — all three arrays sorted (descending by count for
+variant/segment, ascending by date for day).
 
 | Param | Type | Default | Description |
 |-------|------|---------|-------------|
@@ -99,27 +130,64 @@ Response:
 }
 ```
 
+> **Note:** `trafficBySegment` **excludes** rows with `segment_id = 0` (the
+> no-segment-match bucket). Evaluations that matched no segment are still
+> counted in `trafficByVariant` and `trafficByDay`, but do not appear in the
+> per-segment breakdown.
+
 ## Data model
 
-Counts are bucketed by hour using `time.Now().Truncate(time.Hour)`. Each row in the `datar_hourly_events` table represents one unique combination of:
+Datar trades precision for simplicity: it counts evaluations, nothing more.
+There are no per-user rows, no unique-entity counting, no event payloads. Each
+evaluation bumps an in-memory counter keyed by `(flag, variant, segment, hour)`,
+and a background goroutine flushes those counters to one table periodically.
+The trade-off is that you lose entity-level detail (you can't ask "which users
+saw this variant") but you gain a tiny, fast, zero-dependency store that can
+run alongside evaluation without measurable cost.
+
+Counts are bucketed by hour using `time.Now().Truncate(time.Hour)`. Each row
+in the `datar_hourly_events` table represents one unique combination of:
 
 - `flag_id` — the evaluated flag
-- `variant_id` — the matched variant
-- `segment_id` — the matched segment (0 if no segment matched)
 - `bucket_hour` — the truncated hour timestamp
+- `variant_id` — the matched variant
+- `segment_id` — the matched segment (`0` if no segment matched)
 
-A unique index on `(flag_id, variant_id, segment_id, bucket_hour)` ensures additive UPSERTs work correctly across concurrent instances.
+A unique composite index on `(flag_id, bucket_hour, variant_id, segment_id)`
+ensures additive UPSERTs work correctly across concurrent instances.
 
 ## Resource usage
 
-- **CPU**: ~87ns per evaluation on the hot path (existing key), ~98ns for new keys; zero allocations
-- **RAM**: ~210 bytes per active (flag, variant, segment) tuple; ~2.1 MB for 10K keys
-- **DB writes**: One batch transaction every flush interval (configurable, default 60s)
-- **Table growth**: ~2.4K rows/month per 100 flags (hourly buckets, no retention)
+The hot path uses `sync.Map` with atomic increments (zero allocations on the
+existing-key path) and one batch transaction per flush interval.
+
+> **Note:** The numbers below are indicative, not benchmark-verified — the
+> repo currently has no Datar-specific benchmark. Measure on your own hardware
+> before sizing capacity.
+
+- **CPU**: ~87ns per evaluation on the hot path (existing key), ~98ns for new
+  keys; zero allocations.
+- **RAM**: ~210 bytes per active (flag, variant, segment) tuple; ~2.1 MB for
+  10K keys.
+- **DB writes**: One batch transaction every flush interval (configurable,
+  default 60s).
+- **Table growth**: ~2.4K rows/month per 100 flags (hourly buckets, no
+  retention).
 
 ## Limitations
 
-- Data is in-memory until the periodic flush. If the process crashes, up to one flush interval of aggregate data is lost (acceptable for dashboard analytics).
-- No data retention policy is built in — the table grows unbounded. Deploy a cron job or retention policy if needed.
-- No unique entity counting (HyperLogLog or similar). Each evaluation is counted once regardless of the entity identity.
-- **Evaluations only** — rows with `recordSource: exposure` from `POST /exposures` are not counted. Use a streaming recorder (Kafka, Kinesis, or Pub/Sub) and [Data Recorders & A/B Analysis](flagr_eval_exposure_pipeline.md) for impression-based experiments.
+Datar's simplicity comes from what it *doesn't* do. Knowing the boundaries
+tells you when to reach for a streaming recorder instead:
+
+- **Crash loss** — data is in-memory until the periodic flush. If the process
+  crashes, up to one flush interval of aggregate data is lost (acceptable for
+  dashboard analytics).
+- **No retention policy** — the table grows unbounded. Deploy a cron job or
+  retention policy if needed.
+- **No unique entity counting** — each evaluation is counted once regardless
+  of entity identity (no HyperLogLog or similar).
+- **Evaluations only** — rows with `recordSource: exposure` from
+  `POST /exposures` are not counted. Use a streaming recorder (Kafka, Kinesis,
+  or Pub/Sub) and
+  [Data Recorders & A/B Analysis](flagr_eval_exposure_pipeline.md) for
+  impression-based experiments.

--- a/docs/flagr_debugging.md
+++ b/docs/flagr_debugging.md
@@ -1,23 +1,44 @@
 # Debug Console
 
-The Debug Console is a built-in UI tool for testing flag evaluation without leaving the browser. It appears on each flag's detail page and wraps the evaluation API in an interactive JSON editor.
+Evaluations are deterministic, but the *reasoning* behind them — which segment
+matched, which constraints held, where the hash landed — is invisible from a
+raw `POST /evaluation` call. When a user reports "I'm in California but I'm
+not getting the green button," you need to see the trace, not just the answer.
+The Debug Console is that trace, built into each flag's detail page. It wraps
+the evaluation API in an interactive JSON editor so you can replay an
+evaluation with a specific entity context and inspect exactly how Flagr
+arrived at its verdict — without writing a throwaway script or hitting the
+API with curl.
 
-The console exercises `POST /evaluation` only. For production **impression** logging after render, see [Exposure Logging](flagr_exposure.md). Concepts (segments, constraints, rollout) are in the [Overview](flagr_overview.md).
+The console exercises **`POST /evaluation`** and
+**`POST /evaluation/batch`**. For production **impression** logging after
+render, see [Exposure Logging](flagr_exposure.md). For segment, constraint, and
+rollout concepts, see the [Overview](flagr_overview.md).
 
 ![Debug Console](/images/demo_debugging_console.png)
 
 ## What it does
 
-The Debug Console sends evaluation requests to the Flagr API and displays the full response, including debug logs that show exactly how the evaluator arrived at its result. This makes it easy to:
+The Debug Console sends evaluation requests to the Flagr API and displays the
+full response, including debug logs that show how the evaluator arrived at its
+result. Each log entry is keyed to a `segmentID` and carries a free-text `msg`
+that narrates the decision: "matched all constraints" or "constraint not
+match," followed by the bucket and distribution reasoning. Read the trace top
+to bottom to see the segments Flagr considered, in order, and where it
+stopped. Use it to:
 
-- **Verify segment matching** — see which segments were checked and why they matched or didn't
-- **Test constraint logic** — confirm that entity context values trigger the right constraints
-- **Debug distribution** — understand which variant was selected and why
-- **Test before deploying** — simulate evaluations with different entity contexts before rolling out changes
+- **Verify segment matching** — see which segments were checked and whether
+  each matched.
+- **Test constraint logic** — confirm entity-context values trigger the right
+  constraints.
+- **Debug distribution** — understand which variant was selected and why.
+- **Test before deploying** — simulate evaluations with different entity
+  contexts before rolling out changes.
 
 ## Single evaluation
 
-The **Evaluation** panel sends a `POST /api/v1/evaluation` request with a JSON body you can edit inline:
+The **Evaluation** panel sends a `POST /api/v1/evaluation` request with a JSON
+body you can edit inline:
 
 ```json
 {
@@ -31,18 +52,27 @@ The **Evaluation** panel sends a `POST /api/v1/evaluation` request with a JSON b
 
 The response includes:
 
-- **`variantID` / `variantKey`** — which variant was assigned
-- **`evalDebugLog.segmentDebugLogs`** — per-segment breakdown showing:
-  - Whether each segment matched
-  - Which constraints matched and which didn't
-  - The rollout and distribution reasoning
-- **`evalContext`** — the full context that was evaluated
+- **`variantID` / `variantKey`** — which variant was assigned.
+- **`evalDebugLog.segmentDebugLogs`** — a per-segment trace. Each entry has:
+  - `segmentID` — the segment evaluated.
+  - `msg` — free-text reasoning: whether all constraints matched, and the
+    rollout/distribution bucket reasoning (bucket number, distribution array,
+    rollout percent).
+- **`evalContext`** — the full context that was evaluated.
 
-The console also renders a summary view showing the matched variant and a segment-by-segment trace.
+> **Note:** `segmentDebugLogs` is a flat list of `{ segmentID, msg }` entries,
+> not a structured breakdown. Constraint results are reported as one boolean
+> expression per segment — on mismatch the whole expression is dumped; there is
+> no per-constraint matched/didn't split.
+
+The console also renders a summary view showing the matched variant and a
+segment-by-segment trace.
 
 ## Batch evaluation
 
-The **Batch Evaluation** panel sends a `POST /api/v1/evaluation/batch` request, letting you evaluate multiple entities against one or more flags in a single call:
+The **Batch Evaluation** panel sends a `POST /api/v1/evaluation/batch` request,
+letting you evaluate multiple entities against one or more flags in a single
+call:
 
 ```json
 {
@@ -55,10 +85,16 @@ The **Batch Evaluation** panel sends a `POST /api/v1/evaluation/batch` request, 
 }
 ```
 
-This is useful for verifying that different entity contexts route to the correct variants across your segments.
+This is useful for verifying that different entity contexts route to the
+correct variants across your segments.
 
 ## Tips
 
-- **Always set `enableDebug: true`** — without it, the response omits the debug logs that make the console useful.
-- **Use realistic entity contexts** — include the same fields your application sends (e.g. `state`, `age`, `tier`) to test constraint matching accurately.
-- **Flag key or flag ID** — the console pre-fills both from the current flag page. You can use either in the request.
+- **Always set `enableDebug: true`** — without it, the response omits the debug
+  logs that make the console useful. (The server must also have
+  `FLAGR_EVAL_DEBUG_ENABLED` on, which defaults to `true`.)
+- **Use realistic entity contexts** — include the same fields your app sends
+  (e.g. `state`, `age`, `tier`) to test constraint matching accurately.
+- **Flag key or flag ID** — the console pre-fills both from the current flag
+  page. You can use either `flagID` or `flagKey` in the request; both resolve to
+  the same flag.

--- a/docs/flagr_env.md
+++ b/docs/flagr_env.md
@@ -1,16 +1,32 @@
 # Server Configuration
 
-Flagr is configured entirely through environment variables. See [env.go](https://github.com/openflagr/flagr/blob/master/pkg/config/env.go) for the full list.
+Flagr is a single binary with no external runtime dependencies beyond its
+database (and even that is optional). It follows the twelve-factor principle
+of **configuration via the environment**: every knob — database driver, auth
+strategy, recorder backends, cache intervals — is an environment variable,
+parsed once at startup into a single config struct. There are no YAML files,
+no config databases, no hot-reload daemons. This makes Flagr trivial to run
+in a container, easy to configure via Kubernetes secrets, and identical
+across environments when the env vars match. See
+[env.go](https://github.com/openflagr/flagr/blob/master/pkg/config/env.go)
+for the full list.
 
 [env.go](https://raw.githubusercontent.com/openflagr/flagr/master/pkg/config/env.go ':include :type=code')
 
 ```sh
 # Example: set the database driver
 export FLAGR_DB_DBDRIVER=mysql
-# This sets Config.DBDriver = "mysql" at runtime
+# Sets Config.DBDriver = "mysql" at runtime
 ```
 
 ## Database drivers
+
+The driver chooses where flag state lives. For production you'll use MySQL or
+PostgreSQL — a durable, shared store that survives restarts and scales across
+instances. For local development SQLite needs no external process. The two
+`json_*` drivers are a different mode entirely: they skip the database and
+load flags from a file or URL, turning Flagr into an eval-only engine for
+GitOps workflows where Git is the source of truth.
 
 | Driver | Use case |
 |--------|----------|
@@ -20,9 +36,17 @@ export FLAGR_DB_DBDRIVER=mysql
 | `json_file` | Load flags from a local JSON file ([format spec](flagr_json_flag_spec.md)) |
 | `json_http` | Load flags from a URL (CI artifact, S3, GCS) |
 
-For JSON-based workflows (GitOps, eval-only mode), see the [JSON Flag Source](flagr_json_flag_spec.md) guide.
+For JSON-based workflows (GitOps, eval-only mode), see the
+[JSON Flag Source](flagr_json_flag_spec.md) guide.
 
 ## Authentication
+
+By default Flagr's API is open — convenient for a local dev instance behind a
+firewall, dangerous in production. Flagr ships two opt-in auth layers: **Basic
+Auth** for the web UI, and **JWT** for API consumers. Both use *whitelists*
+rather than blanket protection: every path requires credentials *except*
+those you explicitly open. This lets you keep evaluation public (so your app
+can call it without tokens) while guarding flag mutations behind auth.
 
 ### Basic Auth (web interface)
 
@@ -32,22 +56,50 @@ FLAGR_BASIC_AUTH_USERNAME=admin
 FLAGR_BASIC_AUTH_PASSWORD=password
 ```
 
-UI access prompts for username/password. API paths can be whitelisted to skip auth:
+UI access prompts for username/password. API paths can be whitelisted to skip
+auth:
 
 ```sh
 FLAGR_BASIC_AUTH_WHITELIST_PATHS="/api/v1/flags,/api/v1/evaluation"
 FLAGR_BASIC_AUTH_EXACT_WHITELIST_PATHS=""
 ```
 
-> **Note:** Basic auth protects the web UI. It does not prevent direct API calls to `/api/v1/flags`.
+- `WHITELIST_PATHS` uses **prefix** matching (`/api/v1/flags` matches
+  `/api/v1/flags/123`).
+- `EXACT_WHITELIST_PATHS` uses exact path equality.
+
+> **Note:** The **default** `FLAGR_BASIC_AUTH_WHITELIST_PATHS` is
+> `/api/v1/health,/api/v1/flags,/api/v1/evaluation`, so by default the API flag
+> and evaluation endpoints bypass basic auth. Basic auth is not a web-UI-only
+> mechanism — it applies to **every** path; only whitelisted paths skip it.
+> Remove `/api/v1/flags` from the whitelist to require credentials on the API.
 
 ### JWT Auth
 
-Flagr supports JWT-based authentication for API access. Configure the signing key and algorithm via environment variables — see [env.go](https://github.com/openflagr/flagr/blob/master/pkg/config/env.go) for the full list of `FLAGR_JWT_*` options.
+Flagr supports JWT-based authentication for API access. Configure the signing
+key and algorithm via environment variables. Key options (see
+[env.go](https://github.com/openflagr/flagr/blob/master/pkg/config/env.go) for
+the full list):
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `FLAGR_JWT_AUTH_ENABLED` | `false` | Enable JWT auth |
+| `FLAGR_JWT_AUTH_SECRET` | — | Signing secret (HS256/HS512) |
+| `FLAGR_JWT_AUTH_SIGNING_METHOD` | `HS256` | `HS256`, `HS512`, or `RS256` |
+| `FLAGR_JWT_AUTH_WHITELIST_PATHS` | `/api/v1/health,/api/v1/evaluation,/static` | Prefix-whitelisted paths (open when JWT auth is on) |
+| `FLAGR_JWT_AUTH_EXACT_WHITELIST_PATHS` | `/,` | Exact-whitelisted paths |
+| `FLAGR_JWT_AUTH_NO_TOKEN_STATUS_CODE` | `307` | Status when no token is present |
+| `FLAGR_JWT_AUTH_NO_TOKEN_REDIRECT_URL` | — | Optional redirect URL |
 
 ## Data record destinations
 
-Flagr can emit **evaluation** and **exposure** rows to one or more backends when `FLAGR_RECORDER_ENABLED=true` and the flag has `dataRecordsEnabled: true`.
+Evaluation produces a decision; analytics needs a stream of *what happened*.
+Flagr can emit **evaluation** and **exposure** rows to one or more backends —
+the same event, fanned out to every recorder you enable. This is opt-in for a
+reason: recording adds load, and not every flag needs analytics. You turn it
+on globally with `FLAGR_RECORDER_ENABLED=true`, then per-flag with
+`dataRecordsEnabled: true`, so a noisy internal flag never floods your
+Kafka topic while your production experiments stream cleanly.
 
 | Goal | Doc |
 |------|-----|
@@ -55,9 +107,12 @@ Flagr can emit **evaluation** and **exposure** rows to one or more backends when
 | Stream eval + exposure to your pipeline (Kafka, Kinesis, or Pub/Sub) + A/B patterns | [Data Recorders & A/B Analysis](flagr_eval_exposure_pipeline.md) |
 | Built-in eval counts only (no stream, no exposures) | [Datar Analytics](flagr_datar.md) |
 
-Exposure rows use `recordSource: "exposure"` on the same wire shape as evaluations. `FLAGR_EXPOSURE_BATCH_SIZE` (default **100**) caps rows per exposure request.
+Exposure rows use `recordSource: "exposure"` on the same wire shape as
+evaluations. `FLAGR_EXPOSURE_BATCH_SIZE` (default **100**) caps rows per
+exposure request.
 
-Set `FLAGR_RECORDER_TYPE` to a comma-separated list (e.g. `kafka`, `kafka,datar`).
+Set `FLAGR_RECORDER_TYPE` to a comma-separated list (e.g. `kafka`,
+`kafka,datar`). Default: `kafka`.
 
 ### Kafka (default)
 
@@ -68,9 +123,15 @@ FLAGR_RECORDER_KAFKA_BROKERS=kafka1:9092,kafka2:9092
 FLAGR_RECORDER_KAFKA_TOPIC=flagr-records
 ```
 
-Additional Kafka options include SSL/TLS (`FLAGR_RECORDER_KAFKA_CERTFILE`, `FLAGR_RECORDER_KAFKA_KEYFILE`, `FLAGR_RECORDER_KAFKA_CAFILE`), SASL authentication (`FLAGR_RECORDER_KAFKA_SASL_USERNAME`, `FLAGR_RECORDER_KAFKA_SASL_PASSWORD`), idempotent producers, and encryption. See [env.go](https://github.com/openflagr/flagr/blob/master/pkg/config/env.go) for the full list.
+Additional Kafka options include SSL/TLS (`FLAGR_RECORDER_KAFKA_CERTFILE`,
+`FLAGR_RECORDER_KAFKA_KEYFILE`, `FLAGR_RECORDER_KAFKA_CAFILE`), SASL
+authentication (`FLAGR_RECORDER_KAFKA_SASL_USERNAME`,
+`FLAGR_RECORDER_KAFKA_SASL_PASSWORD`), idempotent producers, and encryption.
+See [env.go](https://github.com/openflagr/flagr/blob/master/pkg/config/env.go)
+for the full list.
 
-For consuming eval and exposure events (any streaming recorder) and A/B analysis, see [Data Recorders & A/B Analysis](flagr_eval_exposure_pipeline.md).
+For consuming eval and exposure events (any streaming recorder) and A/B
+analysis, see [Data Recorders & A/B Analysis](flagr_eval_exposure_pipeline.md).
 
 ### Kinesis (AWS)
 
@@ -82,11 +143,15 @@ AWS_SECRET_ACCESS_KEY=example123
 AWS_DEFAULT_REGION=eu-central-1
 ```
 
-Other options include credentials files, container credentials, and instance profiles. See the [AWS documentation](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html#config-settings-and-precedence).
+Other options include credentials files, container credentials, and instance
+profiles. See the
+[AWS documentation](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html#config-settings-and-precedence).
 
 Make sure the IAM key has permissions to push records to the Kinesis stream.
 
-Kinesis and Pub/Sub use the same **record frame** as Kafka for both evaluation and exposure rows. See [Data Recorders & A/B Analysis](flagr_eval_exposure_pipeline.md).
+Kinesis and Pub/Sub use the same **record frame** as Kafka for both evaluation
+and exposure rows. See
+[Data Recorders & A/B Analysis](flagr_eval_exposure_pipeline.md).
 
 ### Pub/Sub (Google Cloud)
 
@@ -101,13 +166,17 @@ For production, create a service account and point to the key file:
 ```sh
 FLAGR_RECORDER_PUBSUB_PROJECT_ID=google-project-id
 FLAGR_RECORDER_PUBSUB_KEYFILE=/path/to/service/account.json
+FLAGR_RECORDER_PUBSUB_TOPIC_NAME=flagr-records
 ```
 
-Alternatively, set `GOOGLE_APPLICATION_CREDENTIALS` (this affects all Google services in the environment).
+Alternatively, set `GOOGLE_APPLICATION_CREDENTIALS` (this affects all Google
+services in the environment).
 
 ### Datar (built-in analytics)
 
-Datar is an optional in-memory aggregate analytics engine. List `datar` in `FLAGR_RECORDER_TYPE` alongside other recorders, or use it alone for a zero-dependency analytics setup:
+Datar is an optional in-memory aggregate analytics engine. List `datar` in
+`FLAGR_RECORDER_TYPE` alongside other recorders, or use it alone for a
+zero-dependency analytics setup:
 
 ```sh
 FLAGR_RECORDER_ENABLED=true
@@ -115,4 +184,5 @@ FLAGR_RECORDER_TYPE=datar
 FLAGR_RECORDER_DATAR_FLUSH_INTERVAL=60s
 ```
 
-See [Datar Analytics](flagr_datar.md) for endpoint documentation, data model, and resource usage.
+See [Datar Analytics](flagr_datar.md) for endpoint documentation, data model,
+and resource usage.

--- a/docs/flagr_env.md
+++ b/docs/flagr_env.md
@@ -69,10 +69,10 @@ FLAGR_BASIC_AUTH_EXACT_WHITELIST_PATHS=""
 - `EXACT_WHITELIST_PATHS` uses exact path equality.
 
 > **Note:** The **default** `FLAGR_BASIC_AUTH_WHITELIST_PATHS` is
-> `/api/v1/health,/api/v1/flags,/api/v1/evaluation`, so by default the API flag
-> and evaluation endpoints bypass basic auth. Basic auth is not a web-UI-only
-> mechanism — it applies to **every** path; only whitelisted paths skip it.
-> Remove `/api/v1/flags` from the whitelist to require credentials on the API.
+> `/api/v1/health,/api/v1/flags,/api/v1/evaluation,/api/v1/exposures`, so by
+> default the flag, evaluation, and exposure endpoints bypass basic auth.
+> Basic auth applies to **every** path; only whitelisted paths skip it.
+> Remove entries from the whitelist to require credentials on those API paths.
 
 ### JWT Auth
 
@@ -86,7 +86,7 @@ the full list):
 | `FLAGR_JWT_AUTH_ENABLED` | `false` | Enable JWT auth |
 | `FLAGR_JWT_AUTH_SECRET` | — | Signing secret (HS256/HS512) |
 | `FLAGR_JWT_AUTH_SIGNING_METHOD` | `HS256` | `HS256`, `HS512`, or `RS256` |
-| `FLAGR_JWT_AUTH_WHITELIST_PATHS` | `/api/v1/health,/api/v1/evaluation,/static` | Prefix-whitelisted paths (open when JWT auth is on) |
+| `FLAGR_JWT_AUTH_WHITELIST_PATHS` | `/api/v1/health,/api/v1/evaluation,/api/v1/exposures,/static` | Prefix-whitelisted paths (open when JWT auth is on) |
 | `FLAGR_JWT_AUTH_EXACT_WHITELIST_PATHS` | `/,` | Exact-whitelisted paths |
 | `FLAGR_JWT_AUTH_NO_TOKEN_STATUS_CODE` | `307` | Status when no token is present |
 | `FLAGR_JWT_AUTH_NO_TOKEN_REDIRECT_URL` | — | Optional redirect URL |

--- a/docs/flagr_eval_exposure_pipeline.md
+++ b/docs/flagr_eval_exposure_pipeline.md
@@ -1,60 +1,96 @@
 # Data Recorders & A/B Analysis
 
-Flagr is an **evaluation engine**: it assigns variants and can **emit events** to your data pipeline. It does **not** run experiment analytics (conversion rates, significance tests, warehouse modeling). That work belongs in **your** consumers, warehouse, and BI tools.
+An evaluation engine that doesn't record its decisions is a black box: you
+know *what* it assigned, but never *whether it mattered*. Flagr's job ends at
+producing a variant and an event; the experiment verdict — conversion,
+significance, lift — is computed downstream, in your warehouse, your stream
+processor, your BI tool. This guide is about the bridge between those two
+worlds: how Flagr emits events, what shape they take, and how to turn them
+into a trustworthy A/B denominator.
+
+Flagr is an **evaluation engine**: it assigns variants and can **emit events**
+to your data pipeline. It does **not** run experiment analytics (conversion
+rates, significance tests, warehouse modeling). That separation is
+deliberate — analytics stacks change slowly and live in your data platform,
+not in your flag service. Flagr's recorder layer is the contract between them.
 
 This guide covers:
 
-1. **Data recorders** — how eval and exposure rows reach Kafka, Kinesis, Pub/Sub, or Datar.
-2. **Wire format** — same `evalResult` JSON for every streaming recorder.
-3. **Downstream handling** — including a **minimal Kafka consumer** as one example.
+1. **Data recorders** — how eval and exposure rows reach Kafka, Kinesis,
+   Pub/Sub, or Datar.
+2. **Wire format** — the same `evalResult` JSON for every streaming recorder.
+3. **Downstream handling** — including a minimal Kafka consumer as one example.
 4. **A/B analysis** — why you need exposures, not just evaluations.
 
-For the exposure API, see [Exposure Logging](flagr_exposure.md). For in-process eval counts only (no exposures), see [Datar](flagr_datar.md). Recorder env vars: [Environment Variables](flagr_env.md#data-record-destinations).
+For the exposure API, see [Exposure Logging](flagr_exposure.md). For in-process
+eval counts only (no exposures), see [Datar](flagr_datar.md). Recorder env vars:
+[Environment Variables](flagr_env.md#data-record-destinations).
 
 ---
 
 ## Two event types on one wire shape
 
-Both paths write the same **`evalResult`** JSON (see [API `evalResult`](https://openflagr.github.io/flagr/api_docs)), distinguished by **`recordSource`**:
+The central design decision in Flagr's recording layer is that evaluation
+and exposure share *one* wire format. They are different events with different
+meanings, but a downstream consumer parses them identically and branches on a
+single field. This keeps your consumer code simple and your pipeline
+schema-stable — you don't maintain two parsers for two topics.
 
 | `recordSource` | Produced by | Meaning |
 |----------------|-------------|---------|
-| `evaluation` | `POST /evaluation` (and batch) | Server **assignment** for this request: which variant (if any) the evaluator returned for the entity. Includes “blank” outcomes (flag disabled, not found, no segment match) when those are logged. |
+| `evaluation` | `POST /evaluation` (and batch) | Server **assignment** for this request: which variant (if any) the evaluator returned for the entity. Includes the no-segment-match blank (no variant assigned). Flag-not-found and flag-disabled paths early-return **before** recording, so they do not appear in the stream. |
 | `exposure` | `POST /exposures` | Client-reported **impression**: the user **saw** the experiment surface for that flag/variant (or flag only if variant omitted). |
 
-**Do not** treat `evaluation` as “user saw the treatment” or `exposure` as “user was assigned.” For conversion analysis you almost always need **exposures** (or your own impression signal) as the experiment **denominator**.
+**Do not** treat `evaluation` as "user saw the treatment" or `exposure` as
+"user was assigned." For conversion analysis you almost always need
+**exposures** (or your own impression signal) as the experiment **denominator**.
 
 ---
 
 ## Data recorders (where events go)
 
-When `FLAGR_RECORDER_ENABLED=true` and a flag has `dataRecordsEnabled: true`, both **evaluation** and **exposure** rows are passed to `GetDataRecorder().AsyncRecord`. A **fan-out** sends each row to every recorder listed in `FLAGR_RECORDER_TYPE` (comma-separated).
+Flagr doesn't pick a streaming backend for you. Instead it fans each event
+out to every recorder you list — so you can stream to Kafka for the data
+team *and* keep lightweight counts in Datar for the dashboard, from one
+evaluation. The recorders are pluggable and share the same frame, which is
+why adding Kinesis to a Kafka setup is a config change, not a code change.
+
+When `FLAGR_RECORDER_ENABLED=true` and a flag has `dataRecordsEnabled: true`,
+both **evaluation** and **exposure** rows are passed to
+`GetDataRecorder().AsyncRecord`. A **fan-out** sends each row to every recorder
+listed in `FLAGR_RECORDER_TYPE` (comma-separated).
 
 | Recorder | `FLAGR_RECORDER_TYPE` | Eval + exposure streaming? | Notes |
-|----------|----------------------|----------------------------|--------|
+|----------|----------------------|----------------------------|-------|
 | **Kafka** | `kafka` | Yes — same serialized frame | Common default; [example consumer](#example-kafka-consumer-python) below |
 | **Kinesis** | `kinesis` | Yes — same frame bytes on the stream | AWS; partition key = `entityID` from the frame |
 | **Pub/Sub** | `pubsub` | Yes — same frame as message payload | Google Cloud |
 | **Datar** | `datar` | **Eval only** | Skips `recordSource: exposure`; REST aggregates, not a warehouse |
 
-You can combine recorders, e.g. `kafka,datar` (stream to Kafka **and** keep lightweight eval totals in Flagr).
+You can combine recorders, e.g. `kafka,datar` (stream to Kafka **and** keep
+lightweight eval totals in Flagr).
 
-**Exposure logging does not require Kafka.** Any streaming recorder above receives exposure rows with `recordSource: "exposure"` using the same JSON envelope as evaluations. Configure the backend your org already uses; parsing and analytics below apply to all streaming recorders.
+**Exposure logging does not require Kafka.** Any streaming recorder above
+receives exposure rows with `recordSource: "exposure"` using the same JSON
+envelope as evaluations. Configure the backend your org already uses; parsing
+and analytics below apply to all streaming recorders.
 
 ---
 
 ## Enable recording
 
-Per-flag **`dataRecordsEnabled`** must be `true`, and the server must have recorders enabled.
+Per-flag **`dataRecordsEnabled`** must be `true`, and the server must have
+recorders enabled.
 
-**Example — Kafka** (for Kinesis or Pub/Sub, set `FLAGR_RECORDER_TYPE` and see [Environment Variables](flagr_env.md)):
+**Example — Kafka** (for Kinesis or Pub/Sub, set `FLAGR_RECORDER_TYPE` and see
+[Environment Variables](flagr_env.md)):
 
 ```bash
 export FLAGR_RECORDER_ENABLED=true
 export FLAGR_RECORDER_TYPE=kafka
 export FLAGR_RECORDER_KAFKA_BROKERS=kafka1:9092,kafka2:9092
 export FLAGR_RECORDER_KAFKA_TOPIC=flagr-records
-export FLAGR_RECORDER_KAFKA_PARTITION_KEY_ENABLED=true
+export FLAGR_RECORDER_KAFKA_PARTITION_KEY_ENABLED=true   # default: true
 ```
 
 **Example — Kinesis only:**
@@ -72,6 +108,7 @@ export FLAGR_RECORDER_ENABLED=true
 export FLAGR_RECORDER_TYPE=pubsub
 export FLAGR_RECORDER_PUBSUB_PROJECT_ID=my-project
 export FLAGR_RECORDER_PUBSUB_TOPIC_NAME=flagr-records
+export FLAGR_RECORDER_PUBSUB_KEYFILE=/path/to/service/account.json   # optional; falls back to GOOGLE_APPLICATION_CREDENTIALS
 ```
 
 Create or update the flag:
@@ -82,15 +119,18 @@ curl -X PUT "http://flagr:18000/api/v1/flags/1" \
   -d '{"dataRecordsEnabled": true}'
 ```
 
-After changing `dataRecordsEnabled`, wait for the eval cache refresh (default ~3s) before expecting records.
+After changing `dataRecordsEnabled`, wait for the eval cache refresh (default
+~3s) before expecting records.
 
-**Datar:** rows with `recordSource: exposure` are **not** counted in Datar. **Kafka, Kinesis, and Pub/Sub** still receive exposure rows when configured.
+**Datar:** rows with `recordSource: exposure` are **not** counted in Datar.
+**Kafka, Kinesis, and Pub/Sub** still receive exposure rows when configured.
 
 ---
 
 ## Record frame format (Kafka, Kinesis, Pub/Sub)
 
-Default mode wraps the eval result in an outer object with a string **`payload`** (JSON-serialized `evalResult`):
+Default mode wraps the eval result in an outer object with a string
+**`payload`** (JSON-serialized `evalResult`):
 
 ```json
 {
@@ -99,13 +139,15 @@ Default mode wraps the eval result in an outer object with a string **`payload`*
 }
 ```
 
-With `FLAGR_RECORDER_FRAME_OUTPUT_MODE=payload_raw_json`, `payload` is embedded JSON instead of a string:
+With `FLAGR_RECORDER_FRAME_OUTPUT_MODE=payload_raw_json`, `payload` is embedded
+JSON instead of a string (and the `encrypted` field is omitted):
 
 ```json
 {
   "payload": {
     "flagID": 1,
     "flagKey": "checkout-button",
+    "flagSnapshotID": 42,
     "recordSource": "exposure",
     "segmentID": 0,
     "variantID": 2,
@@ -116,7 +158,9 @@ With `FLAGR_RECORDER_FRAME_OUTPUT_MODE=payload_raw_json`, `payload` is embedded 
 }
 ```
 
-Partition key (Kafka when `FLAGR_RECORDER_KAFKA_PARTITION_KEY_ENABLED`; Kinesis uses the same `entityID` from the frame) is **`evalContext.entityID`**, useful for co-locating one user’s events.
+Partition key (Kafka when `FLAGR_RECORDER_KAFKA_PARTITION_KEY_ENABLED`,
+default **true**; Kinesis always uses it) is **`evalContext.entityID`** — useful
+for co-locating one user's events.
 
 ---
 
@@ -137,15 +181,18 @@ curl -X POST "http://flagr:18000/api/v1/evaluation" \
   }'
 ```
 
-The data recorder may persist an `evaluation` row when gates pass. That row reflects **this eval call**, not necessarily that the user later viewed the UI.
+The data recorder may persist an `evaluation` row when gates pass. That row
+reflects **this eval call**, not necessarily that the user later viewed the UI.
 
 ### Exposure (impression)
 
 Recommended flow for UI experiments:
 
-1. **Evaluate** → cache `variantID` / `variantKey` / `flagSnapshotID` client-side.
+1. **Evaluate** → cache `variantID` / `variantKey` / `flagSnapshotID`
+   client-side.
 2. **Render** the experiment (button, copy, layout).
-3. **Log exposure** when the surface is actually visible (on mount, in-viewport, or batched on unload):
+3. **Log exposure** when the surface is actually visible (on mount,
+   in-viewport, or batched on unload):
 
 ```bash
 curl -X POST "http://flagr:18000/api/v1/exposures" \
@@ -163,15 +210,19 @@ curl -X POST "http://flagr:18000/api/v1/exposures" \
   }'
 ```
 
-Omit `variantID` / `variantKey` if you only need “saw something for this flag.” Include them when analysis is **per variant**.
+Omit `variantID` / `variantKey` if you only need "saw something for this flag."
+Include them when analysis is **per variant**.
 
 ---
 
 ## Example: Kafka consumer (Python) {#example-kafka-consumer-python}
 
-Kafka is one common destination; **Kinesis and Pub/Sub publish the same outer JSON**—only your client library changes. Read messages, parse `payload`, branch on `recordSource`. This is **not** production-grade (no auth, DLQ, schema registry)—it shows the parsing contract.
+Kafka is one common destination; **Kinesis and Pub/Sub publish the same outer
+JSON** — only your client library changes. Read messages, parse `payload`,
+branch on `recordSource`. This is **not** production-grade (no auth, DLQ,
+schema registry) — it shows the parsing contract.
 
-```
+```python
 #!/usr/bin/env python3
 """Minimal Flagr Kafka consumer — eval vs exposure."""
 
@@ -216,24 +267,12 @@ def main():
 
         if source == "exposure":
             # Impression — use for experiment denominators
-            print(
-                "EXPOSURE",
-                entity_id,
-                flag_key,
-                variant_key,
-                f"snapshot={snapshot_id}",
-                file=sys.stderr,
-            )
+            print("EXPOSURE", entity_id, flag_key, variant_key,
+                  f"snapshot={snapshot_id}", file=sys.stderr)
         elif source == "evaluation":
             # Assignment log — QA, funnel debugging, not a substitute for exposure
-            print(
-                "EVAL",
-                entity_id,
-                flag_key,
-                variant_key,
-                f"segment={record.get('segmentID')}",
-                file=sys.stderr,
-            )
+            print("EVAL", entity_id, flag_key, variant_key,
+                  f"segment={record.get('segmentID')}", file=sys.stderr)
         else:
             print("UNKNOWN recordSource", source, file=sys.stderr)
 
@@ -242,24 +281,43 @@ if __name__ == "__main__":
     main()
 ```
 
-Install: `pip install kafka-python`. In production, prefer your org’s stream processor (Flink, Spark, ksqlDB, Lambda, etc.) with the same **`recordSource`** branch.
+Install: `pip install kafka-python`. In production, prefer your org's stream
+processor (Flink, Spark, ksqlDB, Lambda, etc.) with the same **`recordSource`**
+branch.
 
 ---
 
 ## Using eval + exposure for real A/B analysis
 
-### The problem with eval-only metrics
+The hardest part of A/B testing is not *running* the experiment — it's
+*trusting* the result. A conversion rate is only as good as its denominator.
+[Exposure Logging](flagr_exposure.md) explains why exposure rows (client
+impressions) make a trustworthy denominator where evaluation rows (server
+assignments) do not. The short version: eval runs before render and on every
+navigation; exposure fires once when the user actually sees the surface.
 
-If you count **`evaluation`** rows as “users in the experiment,” you inflate or mis-assign denominators:
+The concrete failure modes when you count `evaluation` rows as participants:
 
-- Eval runs **before** render (prefetch, SSR, background refresh) → user may never see the UI.
-- Eval runs on **every** navigation while exposure should fire **once per meaningful view** (your client rules).
-- Eval logs **failed** paths (`recordSource` still `evaluation`) with empty or zero variant — not experiment participants.
-- **Holdouts** and **rollout %** mean assignment exists without a visible treatment unless you gate rendering.
+- Eval runs **before** render (prefetch, SSR, background refresh) → user may
+  never see the UI.
+- Eval runs on **every** navigation while exposure should fire **once per
+  meaningful view** (your client rules).
+- Eval logs the **no-segment-match blank** with an empty/zero variant — not an
+  experiment participant. (Flag-not-found and flag-disabled paths do not reach
+  the recorder at all.)
+- **Holdouts** and **rollout %** mean assignment exists without a visible
+  treatment unless you gate rendering.
 
-**Exposure** (or an equivalent impression event you own) aligns the denominator with **people who could react** to the variant.
+Use **exposure** (or an equivalent impression event you own) to align the
+denominator with **people who could react** to the variant.
 
 ### A simple legitimate workflow
+
+The trustworthy A/B loop has two tables and one join. The exposure table is
+your denominator (who *saw* which variant, and when). The outcome table is
+your numerator (who *did* the thing you care about). The join, with a time
+window, is your conversion rate. Everything else — significance, Bayesian
+priors, sequential stopping — runs on top of that join, in your warehouse.
 
 ```mermaid
 flowchart LR
@@ -272,10 +330,18 @@ flowchart LR
   G --> H[Metrics per variant]
 ```
 
-1. **Assignment table** (optional): from `evaluation` rows — who was bucketed into which variant and segment at eval time. Useful for debugging bucketing and `flagSnapshotID` alignment.
-2. **Exposure fact table** (recommended denominator): from `exposure` rows — `entity_id`, `flag_id`, `variant_id`, `flag_snapshot_id`, `timestamp`, and `evalContext.entityContext` (one JSON object per row).
-3. **Outcome events**: purchases, signups, clicks — from your app analytics, **not** from Flagr.
-4. **Join** outcomes to **exposures** on `entity_id` (and flag/experiment id), with a **time window** (e.g. outcome within 7 days after first exposure). Use **first exposure per entity per experiment** for classic A/B unless you intentionally analyze repeated views.
+1. **Assignment table** (optional): from `evaluation` rows — who was bucketed
+   into which variant and segment at eval time. Useful for debugging bucketing
+   and `flagSnapshotID` alignment.
+2. **Exposure fact table** (recommended denominator): from `exposure` rows —
+   `entity_id`, `flag_id`, `variant_id`, `flag_snapshot_id`, `timestamp`, and
+   `evalContext.entityContext` (one JSON object per row).
+3. **Outcome events**: purchases, signups, clicks — from your app analytics,
+   **not** from Flagr.
+4. **Join** outcomes to **exposures** on `entity_id` (and flag/experiment id),
+   with a **time window** (e.g. outcome within 7 days after first exposure).
+   Use **first exposure per entity per experiment** for classic A/B unless you
+   intentionally analyze repeated views.
 
 ### Example metrics (conceptual SQL)
 
@@ -318,18 +384,26 @@ LEFT JOIN conversions c
 GROUP BY e.variant_key;
 ```
 
-Run significance tests (chi-square, Bayesian, sequential methods) in your warehouse or notebook — Flagr does not compute them.
+Run significance tests (chi-square, Bayesian, sequential methods) in your
+warehouse or notebook — Flagr does not compute them.
 
 ### `flagSnapshotID` and config changes
 
-Clients may send **`flagSnapshotID`** from the eval response on exposure rows. Downstream, join to your snapshot dimension so analysis uses the **flag version active at impression time**, not today’s config. Flagr passes the ID through; **validating** snapshot/flag pairing is your warehouse’s job.
+Clients may send **`flagSnapshotID`** from the eval response on exposure rows.
+Downstream, join to your snapshot dimension so analysis uses the **flag version
+active at impression time**, not today's config. Flagr passes the ID through;
+**validating** snapshot/flag pairing is your warehouse's job.
 
 ### When evaluation rows are still useful
 
 - **Volume and latency** monitoring of the eval API.
 - **Segment distribution** checks (`segmentID` on eval rows).
-- **Sanity checks**: assignment without matching exposures (integration bugs, ad blockers, never-rendered paths).
-- **Server-side experiments** with no UI (API-only flags) where “exposure” may be defined as “request handled with variant applied” — you may log custom exposure at that point or define denominators from eval **explicitly** in your methodology (document the choice).
+- **Sanity checks**: assignment without matching exposures (integration bugs,
+  ad blockers, never-rendered paths).
+- **Server-side experiments** with no UI (API-only flags) where "exposure" may
+  be defined as "request handled with variant applied" — you may log custom
+  exposure at that point or define denominators from eval **explicitly** in your
+  methodology (document the choice).
 
 ---
 

--- a/docs/flagr_eval_exposure_pipeline.md
+++ b/docs/flagr_eval_exposure_pipeline.md
@@ -347,6 +347,12 @@ flowchart LR
 
 **Exposure counts by variant** (denominator):
 
+The `variant_key` column groups exposures into the arms of your experiment.
+If you followed the `control` / `treatment` naming convention, each treatment's
+count is compared against the control count to measure relative lift. See
+[Use Cases](flagr_use_cases.md#variants-in-experiments-control-and-treatment)
+for the control/treatment definitions.
+
 ```sql
 SELECT
   variant_key,

--- a/docs/flagr_exposure.md
+++ b/docs/flagr_exposure.md
@@ -156,8 +156,12 @@ credentials for impressions, remove `/api/v1/exposures` from
 > **Warning:** `/exposures` is a write endpoint — callers supply the variant
 > and entity, and Flagr records it as an impression. If you leave it open,
 > an unauthenticated caller can submit fabricated impressions and inflate
-> your experiment denominators. Consider requiring auth for deployments where
-> impression integrity matters.
+> your experiment denominators. Flagr does not ship an in-process rate limiter
+> for this endpoint; protect it at your edge (Cloudflare, AWS API Gateway, Kong,
+> or a similar reverse proxy with rate limiting) to bound volume from
+> untrusted sources. For deployments where impression integrity matters, also
+> remove `/api/v1/exposures` from `FLAGR_JWT_AUTH_WHITELIST_PATHS` /
+> `FLAGR_BASIC_AUTH_WHITELIST_PATHS` so impressions require credentials.
 
 Design notes are in the repo under
 `docs/plans/2026-06-25-001-exposure-logging-plan.md`

--- a/docs/flagr_exposure.md
+++ b/docs/flagr_exposure.md
@@ -1,8 +1,23 @@
 # Exposure Logging
 
-Exposure logging records when a user **actually saw** a flag or experiment surface, separate from `POST /evaluation` (assignment). Typical flow: evaluate to get a variant, cache the result client-side, then call `POST /exposures` when the UI renders.
+There is a quiet gap between *assigning* a variant and *showing* it. When you
+call `POST /evaluation`, Flagr decides which treatment a user *should* get —
+but the user never sees that decision until your UI renders. The eval call
+happens on the server, often before render; it runs on every navigation; it
+fires even when the result is "no match." If you count eval calls as
+experiment participants, you'll inflate denominators with users who prefetched,
+scrolled past, or never saw the surface at all.
 
-For data recorders (Kafka, Kinesis, Pub/Sub), wire format, a sample Kafka consumer, and A/B analysis, see [Data Recorders & A/B Analysis](flagr_eval_exposure_pipeline.md).
+Exposure logging closes that gap. It records when a user **actually saw** a
+flag or experiment surface — a client-reported impression, fired on render or
+visibility, separate from the server-side assignment. The typical flow: call
+`POST /evaluation` to get a variant, cache it client-side, then call
+`POST /exposures` when the UI actually shows the treatment. That impression
+is your trustworthy experiment denominator.
+
+For data recorders (Kafka, Kinesis, Pub/Sub), wire format, a sample Kafka
+consumer, and A/B analysis, see
+[Data Recorders & A/B Analysis](flagr_eval_exposure_pipeline.md).
 
 ## Endpoint
 
@@ -26,71 +41,120 @@ Request body:
 }
 ```
 
+Each row also accepts `flagID` and `variantID` as alternatives to the key-based
+fields.
+
 ### `entityContext`
 
-Use the same **`entityContext`** object as `POST /evaluation`: any optional JSON object is stored on the recorded row as `evalContext.entityContext` (for your warehouse or analytics). Put segment-style attributes (`country`, `tier`) and impression-specific attributes (`page`, `component`) in one map — there is no separate `metadata` field. Exposure ingest does **not** re-run segment constraints; context is only copied onto the data record.
+Use the same **`entityContext`** object as `POST /evaluation`: any optional
+JSON object, stored on the recorded row as `evalContext.entityContext` (for
+your warehouse or analytics). Put segment-style attributes (`country`, `tier`)
+and impression-specific attributes (`page`, `component`) in one map — there is
+no separate `metadata` field.
 
-Single impressions use an array of one item. Maximum batch size: `FLAGR_EXPOSURE_BATCH_SIZE` (default **100**).
+> **Warning:** Exposure ingest does **not** re-run segment constraints. Context
+> is only copied onto the data record — it is not evaluated.
+
+Single impressions use an array of one item. Maximum batch size:
+`FLAGR_EXPOSURE_BATCH_SIZE` (default **100**).
 
 ### Typical client flow
 
-1. `POST /evaluation` — get variant assignment.
+1. `POST /evaluation` — get the variant assignment.
 2. Render the experiment surface in the UI.
-3. `POST /exposures` — report that the user saw it (batch on page unload if needed).
-
+3. `POST /exposures` — report that the user saw it (batch on page unload if
+   needed).
 
 ## Response
 
-- **200** with `loggedCount`, `message`, and optional `errors[]` (`index`, `message`) for per-row validation failures.
-- **400** for empty body or batch over limit.
+- **200** with `loggedCount`, `message`, and optional `errors[]` (`index`,
+  `message`) for per-row validation failures.
+- **400** for an empty body or a batch over the limit.
 
-`loggedCount` is the number of rows written to the data recorder. If the recorder is off or the flag’s `dataRecordsEnabled` is false, valid rows still return **200** with `loggedCount: 0`.
+`loggedCount` is the number of rows written to the data recorder. If the
+recorder is off or the flag's `dataRecordsEnabled` is false, valid rows still
+return **200** with `loggedCount: 0`.
 
 ## Recording
 
-Same gate as evaluation data records:
+Exposure rows reuse the exact same recording pipeline as evaluations — the
+same gate, the same fan-out, the same wire format. This is deliberate: your
+downstream consumer doesn't need a second topic or a second parser. The only
+difference is the `recordSource` tag, which lets one consumer route both
+event types. The gate is the same three conditions as evaluation data records:
 
 1. `FLAGR_RECORDER_ENABLED=true`
-2. At least one recorder in `FLAGR_RECORDER_TYPE` (e.g. `kafka`, `kinesis`, `pubsub` — not `datar` alone if you need a stream)
+2. At least one recorder in `FLAGR_RECORDER_TYPE` (e.g. `kafka`, `kinesis`,
+   `pubsub` — not `datar` alone if you need a stream)
 3. Per-flag `dataRecordsEnabled: true`
 
-Recorded rows use the same `evalResult` JSON shape as evaluations on **Kafka, Kinesis, and Pub/Sub**, with `recordSource: "exposure"`. **Datar does not count exposures.** Exposure ingest uses separate Statsd metrics (`exposure.ingest`, `exposure.recorded`).
+Recorded rows use the same `evalResult` JSON shape as evaluations on
+**Kafka, Kinesis, and Pub/Sub**, with `recordSource: "exposure"`. **Datar does
+not count exposures.** Exposure ingest uses separate Statsd metrics
+(`exposure.ingest`, `exposure.recorded`).
 
 ## How this connects to evaluation and `AsyncRecord`
 
-**Evaluation** runs bucketing, then `logEvalResult` (eval Statsd/Prometheus). Results use `recordSource: "evaluation"`. When `dataRecordsEnabled` and `FLAGR_RECORDER_ENABLED`, it calls `GetDataRecorder().AsyncRecord(evalResult)`.
+Understanding the split means understanding the two code paths. Evaluation is
+the *server's* record of a decision; exposure is the *client's* record of an
+impression. They converge at `AsyncRecord` but arrive there differently.
 
-**Exposure** skips `logEvalResult`. For valid rows it builds an exposure `evalResult` with `recordSource: "exposure"` and, when the same gates pass, calls `GetDataRecorder().AsyncRecord` directly.
+**Evaluation** runs bucketing, then `logEvalResult` (eval Statsd/Prometheus).
+Results use `recordSource: "evaluation"`. When `dataRecordsEnabled` and
+`FLAGR_RECORDER_ENABLED`, it calls `GetDataRecorder().AsyncRecord(evalResult)`.
 
-`AsyncRecord` fans out to configured **data recorders** (Kafka, Kinesis, Pub/Sub, Datar). **Datar** ignores rows with `recordSource == exposure`. Exposure uses Statsd `exposure.ingest` / `exposure.recorded`.
+**Exposure** skips `logEvalResult`. For valid rows it builds an exposure
+`evalResult` with `recordSource: "exposure"` and, when the same gates pass,
+calls `GetDataRecorder().AsyncRecord` directly.
+
+`AsyncRecord` fans out to configured **data recorders** (Kafka, Kinesis,
+Pub/Sub, Datar). **Datar** ignores rows with `recordSource == "exposure"`.
+Exposure uses Statsd `exposure.ingest` / `exposure.recorded`.
 
 ### Eval-only mode
 
-`json_file` / `json_http` nodes with eval-only setup register **evaluation** only; **`POST /exposures` is not available** on those deployments.
+`json_file` / `json_http` deployments run in eval-only mode and register
+**evaluation** only; **`POST /exposures` is not available** on those
+deployments.
 
 ### Downstream consumers (Kafka, Kinesis, Pub/Sub)
 
 Filter or branch on `recordSource`:
 
-- `evaluation` — rows from the evaluation API path (`BlankResult`), including not-found/disabled responses; not necessarily a successful variant assignment
-- `exposure` — client-reported impression
+- `evaluation` — rows from the evaluation API path, including the no-segment-
+  match blank (no variant assigned). Flag-not-found and flag-disabled paths
+  early-return **before** recording, so they do not appear in the stream.
+- `exposure` — client-reported impression.
 
 Do not treat exposure rows as assignments for experiment analysis.
 
 ### Statsd (exposure ingest)
 
-Separate from eval `evaluation` metric: `exposure.ingest` (tags: `status=accepted|rejected|recorded`, `FlagID`, `FlagKey`) and `exposure.recorded` when a row is passed to `AsyncRecord`.
+Separate from the eval `evaluation` metric:
+
+- `exposure.ingest` — tags: `status=accepted|rejected|recorded`, `FlagID`,
+  `FlagKey`
+- `exposure.recorded` — emitted when a row is passed to `AsyncRecord`
 
 ## Validation
 
 | Field | Rule |
 |-------|------|
 | `entityID` | Required |
-| `flagID` / `flagKey` | At least one; both must match the same flag |
-| `variantID` / `variantKey` | Optional; if set, must exist on the flag |
-| `flagSnapshotID` | Optional; if set, recorded as sent (downstream can join to snapshots); if omitted, uses current eval-cache snapshot |
+| `flagID` / `flagKey` | At least one; if both present, must match the same flag |
+| `variantID` / `variantKey` | Optional; if set, must exist on the flag (and match each other if both set) |
+| `flagSnapshotID` | Optional; if set, recorded as sent (downstream can join to snapshots); if omitted, uses the current eval-cache snapshot |
 | Disabled flags | Allowed |
 
-Auth matches `POST /evaluation`.
+### Authentication
 
-Design notes are in the repo under `docs/plans/2026-06-25-001-exposure-logging-plan.md` ([view on GitHub](https://github.com/openflagr/flagr/blob/master/docs/plans/2026-06-25-001-exposure-logging-plan.md)).
+> **Warning:** `/exposures` is **not** on the default auth whitelist. When JWT
+> or Basic auth is enabled, `POST /exposures` requires credentials, unlike
+> `POST /evaluation` (which is whitelisted open by default via
+> `FLAGR_JWT_AUTH_WHITELIST_PATHS` / `FLAGR_BASIC_AUTH_WHITELIST_PATHS`). To
+> expose `/exposures` without auth, add `/api/v1/exposures` to the relevant
+> whitelist env var.
+
+Design notes are in the repo under
+`docs/plans/2026-06-25-001-exposure-logging-plan.md`
+([view on GitHub](https://github.com/openflagr/flagr/blob/master/docs/plans/2026-06-25-001-exposure-logging-plan.md)).

--- a/docs/flagr_exposure.md
+++ b/docs/flagr_exposure.md
@@ -148,12 +148,16 @@ Separate from the eval `evaluation` metric:
 
 ### Authentication
 
-> **Warning:** `/exposures` is **not** on the default auth whitelist. When JWT
-> or Basic auth is enabled, `POST /exposures` requires credentials, unlike
-> `POST /evaluation` (which is whitelisted open by default via
-> `FLAGR_JWT_AUTH_WHITELIST_PATHS` / `FLAGR_BASIC_AUTH_WHITELIST_PATHS`). To
-> expose `/exposures` without auth, add `/api/v1/exposures` to the relevant
-> whitelist env var.
+`/exposures` is on the default auth whitelist alongside `/evaluation`, so
+both are open by default when JWT or Basic auth is enabled. To require
+credentials for impressions, remove `/api/v1/exposures` from
+`FLAGR_JWT_AUTH_WHITELIST_PATHS` / `FLAGR_BASIC_AUTH_WHITELIST_PATHS`.
+
+> **Warning:** `/exposures` is a write endpoint — callers supply the variant
+> and entity, and Flagr records it as an impression. If you leave it open,
+> an unauthenticated caller can submit fabricated impressions and inflate
+> your experiment denominators. Consider requiring auth for deployments where
+> impression integrity matters.
 
 Design notes are in the repo under
 `docs/plans/2026-06-25-001-exposure-logging-plan.md`

--- a/docs/flagr_json_flag_spec.md
+++ b/docs/flagr_json_flag_spec.md
@@ -1,6 +1,13 @@
 # JSON Flag Source
 
-Flagr can load flags from a JSON file instead of a database. This is the foundation for GitOps workflows — manage flags as code, validate before deploy, and let Flagr serve them.
+Not every team wants a database to own their flag configuration. Some want
+flags checked into Git alongside the code that consumes them — reviewed in
+PRs, diffed in commits, rolled back with `git revert`. Flagr meets that need
+by loading flags from a JSON file (or URL) instead of a database. The same
+evaluation engine runs; only the source of truth changes. This is the
+foundation for GitOps: manage flags as code, validate before deploy, and let
+Flagr serve them read-only. There is no CRUD API in this mode — edits happen
+in Git, Flagr reloads on its own.
 
 ## Quick start
 
@@ -30,9 +37,16 @@ export FLAGR_DB_DBDRIVER=json_file       # or json_http
 export FLAGR_DB_DBCONNECTIONSTR=/path/to/flags.json
 ```
 
-Flagr reloads flags automatically on the cache refresh interval (default: 3 seconds).
+Flagr reloads flags automatically on the cache refresh interval (default:
+**3 seconds**).
 
 ## Validation
+
+A broken flag file doesn't just fail to load — it can take your evaluation
+path down at reload time. The standalone `flagr-validate` binary lets you
+catch problems in CI, *before* the file reaches a running Flagr. It runs the
+same `ValidateFlags()` the server uses at load time, so what passes in CI
+passes in production.
 
 Validate your flag file before deploying:
 
@@ -41,29 +55,57 @@ go build -o flagr-validate ./cmd/flagr-validate/
 ./flagr-validate flags.json
 ```
 
-The validator checks: valid JSON, required fields, key uniqueness, distribution sums (must be 100), variant references, constraint expressions, and percentage ranges. It reports errors (must fix) and warnings (should fix) separately.
+The validator checks:
 
-You can also use `ValidateFlags()` from `pkg/handler` programmatically.
+- Valid JSON
+- Required fields
+- Key uniqueness
+- Distribution sums (must be **100** when ≥1 distribution exists)
+- Variant references (`VariantKey` / `VariantID` resolve to a real variant)
+- Constraint expressions (operator validity, non-empty property/value, regex
+  parses)
+- Percentage ranges (`0–100`)
+
+It reports **errors** (must fix) and **warnings** (should fix) separately.
+Errors block the file from loading; warnings are logged but do not block.
+
+> **Note:** `Tag.Value` is **not** validated by `ValidateFlags` — an empty or
+> missing tag value passes validation and loads. Uniqueness is enforced only at
+> the DB layer (for DB-backed deployments), not by the JSON validator.
+
+You can also call `ValidateFlags()` from `pkg/handler` programmatically.
 
 ## GitOps with GitHub
 
-Host your `flags.json` in a Git repository and point Flagr at the raw file. This gives you full GitOps: PR review, audit trail, rollback via `git revert`, and CI validation before deploy.
+The full GitOps loop has four parts: **author** in Git, **review** in a PR,
+**validate** in CI, **serve** from Flagr. Pointing Flagr at the raw file URL
+closes the loop — when a PR merges, the URL serves the new content and Flagr
+picks it up on its next refresh. No deploy step, no SSH, no CI job pushing to
+Flagr. The audit trail is the commit history; rollback is `git revert`.
+
+Host your `flags.json` in a Git repository and point Flagr at the raw file.
+This gives you full GitOps: PR review, audit trail, rollback via `git revert`,
+and CI validation before deploy.
 
 ### Setup
 
 1. **Create a GitHub Personal Access Token** (fine-grained, repo-scoped):
-   - Go to **Settings → Developer settings → Personal access tokens → Fine-grained tokens**
+   - Go to **Settings → Developer settings → Personal access tokens →
+     Fine-grained tokens**
    - Scope to the repository containing your flags file
    - Grant **Read access to Contents**
 
-2. **Point Flagr at the raw file** using `json_http` with the token embedded in the URL:
+2. **Point Flagr at the raw file** using `json_http` with the token embedded in
+   the URL:
 
    ```sh
    export FLAGR_DB_DBDRIVER=json_http
    export FLAGR_DB_DBCONNECTIONSTR="https://<PAT>@raw.githubusercontent.com/<owner>/<repo>/<ref>/flags.json"
    ```
 
-   The token is used as HTTP Basic Auth username (the password is empty), which Go's `net/http` handles transparently. GitHub accepts this for raw content access.
+   The token is used as HTTP Basic Auth username (the password is empty), which
+   Go's `net/http` handles transparently. GitHub accepts this for raw content
+   access.
 
    **Example** — load from a private repo's `main` branch:
 
@@ -73,9 +115,12 @@ Host your `flags.json` in a Git repository and point Flagr at the raw file. This
 
 ### Security notes
 
-- Use a **fine-grained token** with the narrowest scope possible (single repo, read-only Contents).
-- The token is visible in the environment and process listing. On shared hosts, restrict access to the env file (e.g., `chmod 600`).
-- Consider a dedicated machine account for the token rather than a personal account.
+- Use a **fine-grained token** with the narrowest scope possible (single repo,
+  read-only Contents).
+- The token is visible in the environment and process listing. On shared hosts,
+  restrict access to the env file (e.g. `chmod 600`).
+- Consider a dedicated machine account for the token rather than a personal
+  account.
 - Rotate tokens on a schedule; GitHub fine-grained tokens support expiration.
 
 ### CI validation
@@ -87,9 +132,16 @@ go build -o flagr-validate ./cmd/flagr-validate/
 ./flagr-validate flags.json
 ```
 
-Failing validation blocks the PR — broken flag config never reaches your running instances.
+Failing validation blocks the PR — broken flag config never reaches your
+running instances.
 
 ## JSON format
+
+The format mirrors the entity model: one `Flags` array at the root, each flag
+nested with its segments, variants, constraints, distributions, and tags.
+Because this is a hand-edited (or machine-generated) artifact, IDs are
+optional — Flagr assigns them on load — and distributions can reference
+variants by key rather than by numeric ID, so the file stays readable.
 
 The root object contains a single `Flags` array:
 
@@ -101,9 +153,16 @@ The root object contains a single `Flags` array:
 
 ### IDs are optional
 
-All entity IDs (flags, variants, segments, constraints, distributions, tags) are **auto-assigned** if omitted. This means hand-edited files can skip IDs entirely. If you do provide them, they must be globally unique per entity type.
+All entity IDs (flags, variants, segments, constraints, distributions, tags)
+are **auto-assigned** if omitted. Hand-edited files can skip IDs entirely. If
+you provide them, they must be globally unique per entity type.
 
-Distributions can reference variants by `VariantKey` instead of `VariantID` — the system resolves the link automatically.
+Distributions can reference variants by `VariantKey` instead of `VariantID` —
+the system resolves the link automatically on load.
+
+> **Note:** `SegmentDefaultRank` (`999`) is applied by the **CRUD API** when
+> creating segments, **not** by the JSON loader. If you omit `Rank` in a JSON
+> flag, it stays `0` — set it explicitly when segment order matters.
 
 ### Flag
 
@@ -130,7 +189,7 @@ Distributions can reference variants by `VariantKey` instead of `VariantID` — 
 | `Variants` | array | no | Possible evaluation outcomes |
 | `Tags` | array | no | Searchable tags |
 | `Notes` | string | no | Markdown notes (supports KaTeX in the UI) |
-| `DataRecordsEnabled` | bool | no | Log evaluation data to metrics pipeline |
+| `DataRecordsEnabled` | bool | no | Log evaluation data to the metrics pipeline |
 | `EntityType` | string | no | Override entity type in evaluation logs |
 
 ### Variant
@@ -162,8 +221,8 @@ Distributions can reference variants by `VariantKey` instead of `VariantID` — 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `Description` | string | no | Human-readable description |
-| `Rank` | uint | no | Evaluation priority (lower = higher priority). Default: 999 |
-| `RolloutPercent` | uint | no | Percentage of users matching this segment (0-100) |
+| `Rank` | uint | no | Evaluation priority (lower = higher priority). **Defaults to `0` in JSON** (the `999` default only applies to the CRUD API) |
+| `RolloutPercent` | uint | no | Percentage of users matching this segment (`0–100`) |
 | `Constraints` | array | no | Conditions that must match |
 | `Distributions` | array | no | How to route matched users across variants |
 
@@ -179,11 +238,11 @@ Distributions can reference variants by `VariantKey` instead of `VariantID` — 
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `Property` | string | yes | Entity property to evaluate (e.g., `"country"`, `"age"`) |
+| `Property` | string | yes | Entity property to evaluate (e.g. `"country"`, `"age"`) |
 | `Operator` | string | yes | Comparison operator (see below) |
-| `Value` | string | yes | Value to compare against |
+| `Value` | string | yes | Value to compare against (JSON-encoded) |
 
-**Operators:**
+**Operators** (12 supported):
 
 | Operator | Description | Example Value |
 |----------|-------------|---------------|
@@ -212,8 +271,8 @@ Distributions can reference variants by `VariantKey` instead of `VariantID` — 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `VariantKey` | string | yes* | Target variant key |
-| `VariantID` | uint | yes* | Target variant ID (alternative to VariantKey) |
-| `Percent` | uint | yes | Percentage of segment traffic (0-100). **Must sum to 100 across all distributions in a segment.** |
+| `VariantID` | uint | yes* | Target variant ID (alternative to `VariantKey`) |
+| `Percent` | uint | yes | Percentage of segment traffic (`0–100`). **Must sum to 100 across all distributions in a segment** (enforced when ≥1 distribution exists; zero distributions yields a warning) |
 
 *Either `VariantKey` or `VariantID` is required.
 
@@ -227,10 +286,15 @@ Distributions can reference variants by `VariantKey` instead of `VariantID` — 
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `Value` | string | yes | Tag value |
+| `Value` | string | yes¹ | Tag value |
+
+¹ `Value` is required by the schema, but `ValidateFlags` does not enforce it —
+an empty value loads without error.
 
 ## Complete example
+
 Two flags, no explicit IDs — the system auto-assigns them on load.
+
 ```json
 {
   "Flags": [

--- a/docs/flagr_notifications.md
+++ b/docs/flagr_notifications.md
@@ -1,49 +1,96 @@
 # Notifications
 
-Flagr provides an integrated notification system that allows you to monitor changes and updates to your operational resources in real-time. You can configure Flagr to send HTTP `POST` webhooks whenever a flag is created, updated, deleted, or restored.
+Flag configuration changes are high-leverage events: a rollout percentage
+creep, a disabled flag, a swapped distribution can change the experience for
+every user in seconds. In a team, you want those changes to *announce
+themselves* — to trigger an audit trail, a cache invalidation, a Slack alert,
+or a sync to an external config store. Flagr's notification system does this
+by sending an HTTP `POST` webhook whenever a flag is created, updated,
+deleted, or restored. The webhook carries what changed, on which flag, by
+whom, and (optionally) a JSON diff — so the receiver can decide whether to
+act, log, or alarm. Delivery is asynchronous and never blocks the API
+response that made the change.
 
-## Tracked Operations
+## Tracked operations
 
-Flagr monitors changes to **flags** and their related configuration. All notifications have `EntityType: "flag"` in the payload.
+Notifications fire on mutations to a flag and its related entities (segments,
+variants, constraints, distributions, tags). The `operation` field identifies
+what happened:
 
-The following operations trigger notifications:
-
-| Operation | Description |
-|-----------|-------------|
-| `create` | A new flag is created |
-| `update` | Any change to a flag's metadata, enabled state, or any of its associated entities (segments, variants, constraints, distributions, tags) |
-| `delete` | A flag is soft-deleted |
+| Operation | Fires when |
+|-----------|------------|
+| `create` | A flag is created, **or** a segment, variant, constraint, or tag is created on a flag |
+| `update` | A flag's metadata, enabled state, segments, variants, constraints, distributions, or tags are modified |
+| `delete` | A flag is soft-deleted, **or** a segment, variant, constraint, or tag is deleted from a flag |
 | `restore` | A soft-deleted flag is restored |
 
-**Note**: Operations such as adding/removing tags, updating segment rollout percentages, modifying constraints, or changing variant attachments all trigger an `update` notification for the parent flag. Enabling or disabling a flag is also considered an update.
+The `component_type` field identifies **what** changed (`flag`, `segment`,
+`variant`, `constraint`, `distribution`, or `tag`).
+
+> **Note:** Enabling or disabling a flag is an `update` with
+> `component_type: "flag"`. Reordering segments is an `update` with
+> `component_type: "segment"`. Changing distributions is an `update` with
+> `component_type: "distribution"`.
 
 ## Configuration
 
-To enable notifications, set the following environment variables:
+Notifications are off by default — a Flagr instance with no webhook
+destination stays silent. Turning it on is a single env var; the rest tunes
+the delivery. Retries exist because webhook endpoints *do* go down, and a
+flag change you lose is one you can't audit.
 
-- `FLAGR_NOTIFICATION_WEBHOOK_ENABLED=true` (Default: `false`) — Enable webhook notifications.
-- `FLAGR_NOTIFICATION_WEBHOOK_URL=https://api.your-org.com/webhooks/flagr` — HTTP destination endpoint for POST requests.
-- `FLAGR_NOTIFICATION_WEBHOOK_HEADERS=Authorization: Bearer secret-token, X-Custom-Header: value` — (Optional) Custom comma-separated HTTP headers, often utilized for securing your webhook receiver with an API token.
-- `FLAGR_NOTIFICATION_TIMEOUT=10s` (Default: `10s`) — Configures the timeout window for dialing the webhook endpoint.
-- `FLAGR_NOTIFICATION_DETAILED_DIFF_ENABLED=true` (Default: `false`) — When enabled, Flagr will embed the precise visual JSON diff of the modified flag within the notification payload.
-- `FLAGR_NOTIFICATION_MAX_RETRIES=3` (Default: `3`) — Maximum number of retry attempts for transient HTTP failures (5xx errors). Set to `0` to disable retries.
-- `FLAGR_NOTIFICATION_RETRY_BASE=1s` (Default: `1s`) — Base delay for exponential backoff between retries.
-- `FLAGR_NOTIFICATION_RETRY_MAX=10s` (Default: `10s`) — Maximum delay between retries.
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `FLAGR_NOTIFICATION_WEBHOOK_ENABLED` | `false` | Enable webhook notifications |
+| `FLAGR_NOTIFICATION_WEBHOOK_URL` | — | HTTP destination endpoint for POST requests |
+| `FLAGR_NOTIFICATION_WEBHOOK_HEADERS` | — | Comma-separated custom HTTP headers (e.g. `Authorization: Bearer token, X-Custom: value`) |
+| `FLAGR_NOTIFICATION_TIMEOUT` | `10s` | Timeout for dialing the webhook endpoint |
+| `FLAGR_NOTIFICATION_DETAILED_DIFF_ENABLED` | `false` | Embed the JSON diff of the modified flag in the payload |
+| `FLAGR_NOTIFICATION_MAX_RETRIES` | `3` | Max retry attempts for transient HTTP failures (5xx). Set `0` to disable retries |
+| `FLAGR_NOTIFICATION_RETRY_BASE` | `1s` | Base delay for exponential backoff between retries |
+| `FLAGR_NOTIFICATION_RETRY_MAX` | `10s` | Maximum delay between retries |
 
-### Concurrency & Observability
+### Delivery behavior
 
-- Notifications are sent asynchronously with a default concurrency limit of 100 to prevent resource exhaustion under load.
-- Metric `notification.sent` is emitted when statsd is enabled, tagged with `provider`, `operation`, `entity_type`, and `status` (`success`/`failure`).
+Flagr treats notification delivery as best-effort: the API call that changed
+the flag returns immediately, and the webhook fires in the background. This is
+a deliberate trade-off — you don't want a flaky webhook receiver to stall a
+flag update — but it means your receiver must be idempotent and observably
+reliable on its own.
 
-### Important Notes
+- **Asynchronous** — notifications are sent in background goroutines. Failures
+  are logged but **do not affect the API response**.
+- **Concurrency** — a hardcoded semaphore limits delivery to **100** concurrent
+  notifications to prevent resource exhaustion under load.
+- **Retry** — on HTTP `5xx`, the webhook retries up to `MAX_RETRIES` times with
+  exponential backoff (delay doubling, capped at `RETRY_MAX`, with jitter).
+  `4xx` responses are treated as final (no retry).
+- **Silent fallback** — if webhooks are enabled but `FLAGR_NOTIFICATION_WEBHOOK_URL`
+  is missing, notifications are dropped. Flagr logs a warning at startup.
 
-- **Asynchronous delivery**: Notifications are sent in background goroutines. Failures are logged but **do not affect the API response**.
-- **Startup validation**: Flagr validates the notification configuration at startup and logs a warning if `FLAGR_NOTIFICATION_WEBHOOK_URL` is not set while webhooks are enabled.
-- **Silent fallback**: If webhooks are enabled but the URL is missing, notifications will be silently dropped. A warning is logged at startup to help diagnose misconfiguration.
+### Observability
 
-## Webhook Payload Format
+The Statsd counter `notification.sent` is emitted for every delivery attempt,
+tagged with:
 
-The target endpoint receives a structured JSON payload:
+- `provider` — the notifier (e.g. `webhook`)
+- `operation` — `create`, `update`, `delete`, or `restore`
+- `status` — `success` or `failure`
+
+> **Note:** Flagr validates the notification configuration at startup and logs
+> a warning if `FLAGR_NOTIFICATION_WEBHOOK_URL` is not set while webhooks are
+> enabled.
+
+## Webhook payload
+
+The payload is intentionally flat and self-describing: one JSON object per
+event, with the `operation` and `component_type` telling the receiver what
+happened and to what, and the `flag_id`/`flag_key` anchoring it to a flag your
+system already knows. The optional diff fields (`pre_value`, `post_value`,
+`diff`) carry the full before/after snapshot when you want rich change
+records — off by default because they roughly double the payload size.
+
+The target endpoint receives a JSON payload:
 
 ```json
 {
@@ -66,11 +113,11 @@ The target endpoint receives a structured JSON payload:
 | `operation` | string | `create`, `update`, `delete`, or `restore` |
 | `flag_id` | uint | Database ID of the parent flag |
 | `flag_key` | string | Unique key of the parent flag |
-| `component_type` | string | What part of the flag changed: `flag`, `segment`, `variant`, `constraint`, `distribution`, or `tag` |
+| `component_type` | string | What changed: `flag`, `segment`, `variant`, `constraint`, `distribution`, or `tag` |
 | `component_id` | uint | Database ID of the changed component |
 | `component_key` | string | Key/name of the changed component (e.g. variant key, tag value) |
-| `pre_value` | string | Previous flag snapshot JSON (only if `FLAGR_NOTIFICATION_DETAILED_DIFF_ENABLED=true`)
-| `post_value` | string | Current flag snapshot JSON (only if `FLAGR_NOTIFICATION_DETAILED_DIFF_ENABLED=true`)
-| `diff` | string | Unified diff between previous and current (only if `FLAGR_NOTIFICATION_DETAILED_DIFF_ENABLED=true`)
+| `pre_value` | string | Previous flag snapshot JSON (only if `FLAGR_NOTIFICATION_DETAILED_DIFF_ENABLED=true`) |
+| `post_value` | string | Current flag snapshot JSON (only if `FLAGR_NOTIFICATION_DETAILED_DIFF_ENABLED=true`) |
+| `diff` | string | Unified diff between previous and current (only if `FLAGR_NOTIFICATION_DETAILED_DIFF_ENABLED=true`) |
 | `user` | string | Identity of the user who made the change |
 | `timestamp` | string | UTC timestamp of the change in RFC 3339 format |

--- a/docs/flagr_overview.md
+++ b/docs/flagr_overview.md
@@ -1,63 +1,182 @@
 # Flagr Overview
 
-## Flagr Concepts
+Every evaluation in Flagr answers one question: *given this entity, which
+variant should it get — right now?* The machinery behind that answer is
+small, deterministic, and fast. This page explains the concepts that make up
+that question, the algorithm that resolves it, and the architecture that
+serves it at low latency.
 
-The definitions of the following concepts are in [API doc](https://openflagr.github.io/flagr/api_docs).
+## Concepts
 
-- **Flag**. It can be a feature flag, an experiment, or a configuration.
-- **Tag**. This is a descriptive label attached to a flag for easy lookup and evaluation.
-- **Variant** represents the possible variation of a flag. For example, control/treatment, green/yellow/red, etc.
-- **Variant Attachment** represents the dynamic configuration of a variant. For example, if you have a variant for the `green` button, you can dynamically control what's the hex color of green you want to use (e.g. `{"hex_color": "#42b983"}`).
-- **Segment** represents the segmentation, i.e. the set of audience we want to target. Segment is the smallest unit of a component we can analyze in Flagr Metrics.
-- **Constraint** represents rules that we can use to define the audience of the segment. In other words, the audience in the segment is defined by a set of constraints. Specifically, in Flagr, the constraints are connected with `AND` in a segment.
+For the authoritative field definitions, see the
+[API doc](https://openflagr.github.io/flagr/api_docs).
 
-  Constraint properties support nested field access using dotted and bracketed syntax:
-  - `user.name` — accesses `args["user"]["name"]` from a nested entity context
-  - `users[0]` — accesses the first element of `args["users"]` array
-  - `users[0].role` — chained array + property access
-  - Simple flat properties like `state` or `age` work as before.
-- **Distribution** represents the distribution of variants in a segment.
-- **Entity** represents the context of what we are going to assign the variant on. Usually, Flagr expects the context coming with the entity, so that one can define constraints based on the context of the entity.
-- **Rollout** and deterministic random logic. The goal here is to ensure deterministic and persistent evaluation result for entities. Steps to evaluating a flag given an entity context:
-    - Take the unique ID from the entity, hash it using a hash function that has a uniform distribution (e.g. CRC32, MD5).
-    - Take the hash value (base 10) and mod 1000. 1000 is the total number of buckets used in Flagr.
-    - Consider the distribution. For example, 50/50 split for control and treatment means 0-499 for control and 500-999 for treatment.
-    - Consider the rollout percentage. For example, 10% rollout means only the first 10% of the control buckets (again, use the previous step example, 0-49 out of 0-499 will be rolled out to control experience).
+- **Flag** — A decision point in your application. Behind it lives the question
+  you want to answer at runtime: *who gets what?* A flag can act as a feature
+  flag (on/off), an experiment (control vs. treatment), or a configuration
+  (which JSON to serve). It is the top-level unit you evaluate against.
+- **Tag** — A descriptive label attached to a flag for easy lookup and
+  filtering. Tags let you group flags by team, surface, or lifecycle
+  ("frontend", "experiment", "ops") without encoding that into the flag key.
+- **Variant** — One possible outcome of a flag (`control`/`treatment`,
+  `green`/`yellow`/`red`). Each variant carries an **Attachment** (an
+  arbitrary JSON object) for dynamic configuration. The same variant mechanism
+  that picks a button color can also carry the hex code, a copy string, or a
+  timeout value — so the client never has to branch on business logic, only on
+  the `variantKey`.
+- **Segment** — The audience you want to target; the smallest unit you can
+  analyze in Flagr Metrics. A segment is defined by a set of **Constraints**
+  (connected by `AND`). Segments are evaluated in rank order, and an entity
+  falls into the **first** segment that matches — so ordering is how you
+  express "specific audiences first, everyone else last."
+- **Constraint** — A rule on the entity context, e.g. `state == "CA"` or
+  `age >= 21`. All constraints in a segment must match (`AND`). Constraints are
+  what make a flag *targeted* rather than global — they let you say "only
+  users in California, on mobile, over 21" without writing that logic in your
+  app.
+- **Distribution** — How matched entities are split across variants within a
+  segment. A `50/50` split of `control`/`treatment` is the bread and butter of
+  A/B testing; a `100/0` split is a rollout. Distribution turns a segment from
+  a *who* into a *who gets which*.
+- **Entity** — The context you evaluate against (`entityID`, `entityType`,
+  `entityContext`). The `entityID` is what makes evaluation **deterministic**:
+  the same ID always hashes to the same bucket, so a user sees the same variant
+  on every request. Constraints read fields from `entityContext`.
 
-## Flagr Running Example
+> **Note:** "Variant Attachment" in these docs refers to the `Attachment` field
+> on the `Variant` entity (type `map[string]any` — arbitrary JSON). There is no
+> separate `VariantAttachment` type.
 
-- Suppose we want to roll out a new button to users in US, and we don't know which color works best. The colors `green/blue/pink` are three variants of the flag.
+### Constraint property access
+
+Constraint `Property` supports nested field access via dotted and bracketed
+syntax against `entityContext`:
+
+| Syntax | Resolves to |
+|--------|-------------|
+| `state` | `entityContext["state"]` (flat, as before) |
+| `user.name` | `entityContext["user"]["name"]` |
+| `users[0]` | `entityContext["users"][0]` |
+| `users[0].role` | `entityContext["users"][0]["role"]` |
+
+Missing keys, out-of-bounds indices, and type mismatches evaluate to
+**no match** (the segment does not match) rather than erroring. Negative
+indices are supported (`users[-1]` = last element).
+
+## Running example
+
+The best way to see how the concepts compose is to follow one flag through its
+lifecycle — from a cautious rollout to a targeted experiment to a full launch.
+Suppose we want to ship a new button to US users, but we don't yet know which
+color works best. `green` / `blue` / `pink` are the three variants.
+
 ![](images/flagr_running_example_1.png)
 ![](images/flagr_running_example_4.png)
 
-- We may want to expose the flag to a small set of users, for example users in California. So users in California is a segment.
+Start by exposing the flag to a small audience, e.g. users in California:
+
 ![](images/flagr_running_example_2.png)
 
-- Later, we learned that users in CA liked the green button, people in NY liked the pink button, and people in DC liked the blue button. So we will have three segments, and each segment is defined by the constraint: `state == ?`. The segment can also be defined by multiple constraints. For example, `state == NY AND Age >= 21`
+Later, learn that CA users like green, NY users like pink, DC users like blue —
+so add three segments, each defined by `state == ?`. A segment can combine
+multiple constraints, e.g. `state == "NY" AND age >= 21`:
+
 ![](images/flagr_running_example_3.png)
 ![](images/flagr_running_example_5.png)
 
-- To run A/B testing for this flag, we can try `50%/50%` (Distribution) of `green/blue`, and test this only on `20%` (Rollout Percent) of the users in the `CA` segment. Later on we can set the rollout percent to be `100%` so that every user in `CA` will get either green or blue with `50%` of the chance. And of course, if you want to roll it out to `100%` green to `100%` of the users, just set distribution to be `100%/0%` green/blue and `100%` rollout percentage.
+To A/B test, split `green`/`blue` `50%/50%` (distribution) on `20%` (rollout)
+of the CA segment. Raise rollout to `100%` later so every CA user gets green or
+blue. To ship `100%` green to `100%` of users, set distribution `100%/0%`
+green/blue and rollout `100%`.
+
 ![](images/flagr_running_example_7.png)
 ![](images/flagr_running_example_6.png)
 
-## Flagr Architecture
+## Rollout and deterministic bucketing
 
-There are three components in the flagr, Flagr Evaluator, Flagr Manager, and Flagr Metrics.
+The defining property of a good feature-flag engine is **stickiness**: the
+same user must see the same variant on every request, even across restarts,
+redeploys, and load-balanced instances. Flagr achieves this without storing
+any per-user state. Instead it derives the variant **deterministically** from
+the entity ID, so the answer is reproducible anywhere the same flag
+configuration is loaded.
 
-- **Flagr Evaluator**. Flagr evaluator evaluates the incoming requests. It maintains an in-memory cache (`EvalCache`) of all flags, segments, variants, constraints, distributions, and tags — pre-parsed and ready for fast evaluation. The cache is refreshed periodically (default every 3s, configurable via `FLAGR_EVALCACHE_REFRESHINTERVAL`). To avoid unnecessary database load, the reload short-circuits when no new `flag_snapshot` rows have been created, since every mutation handler that affects evaluation data also creates a snapshot.
+Given an entity context, evaluation works as follows:
 
-  The lightweight endpoint `GET /api/v1/flags/snapshots/max_id` exposes the current max `flag_snapshot` id — a monotonically increasing version counter for the entire flag configuration. External caching layers (CDN, sidecar proxies, application-level caches) can poll this single endpoint and compare the value with their last-known version: if the value changed, at least one flag's configuration was modified and cached evaluations should be invalidated. This is vastly more efficient than polling individual flag records.
+1. **Hash** — `crc32.ChecksumIEEE(flagIDString + entityID)`.
+2. **Modulo 1000** — the hash mod `1000` (the total bucket count) gives a
+   bucket in `[0, 999]`.
+3. **Distribution** — variants occupy contiguous bucket ranges. A `50/50`
+   split of control/treatment means buckets `0–499` → control, `500–999` →
+   treatment.
+4. **Rollout** — the rollout percentage truncates the variant's bucket range.
+   Within the variant's range, only the first `rolloutPercent` of buckets
+   receive the variant; the rest fall through to the next segment (or no match).
 
-- **Flagr Manager**. Flagr manager is the CRUD gateway. All the mutations of flags happen here.
-- **Flagr Metrics**. Evaluation results and client-reported exposures (`POST /api/v1/exposures`) flow through the same **data recorders** when per-flag `dataRecordsEnabled` is on. Streaming options: **Kafka**, **AWS Kinesis**, and **Google Pub/Sub** (same wire format for eval and exposure). **Datar** is eval-only and skips exposure rows. Combine recorders via `FLAGR_RECORDER_TYPE`. See [Data Recorders & A/B Analysis](flagr_eval_exposure_pipeline.md).
+> **Note:** The rollout percentage is applied **within whichever variant's
+> bucket sub-range the entity hashed into**, not to a specific variant's full
+> range. This means a low rollout can cause a matched segment to still not
+> assign a variant, letting evaluation continue to later segments.
+
+## Architecture
+
+Flagr separates the three things that have different scaling and consistency
+needs: **reading** an evaluation (hot, frequent, must be fast and stale-tolerant),
+**writing** a flag mutation (cold, rare, must be consistent), and **recording**
+what happened (asynchronous, lossy-by-design, must not slow down the request).
+Each lives in its own component so evaluation is never blocked by a database
+write or a slow analytics pipeline.
+
+Flagr has three components: **Evaluator**, **Manager**, and **Metrics**.
+
+### Flagr Evaluator
+
+The Evaluator is the hot path. It serves evaluation requests from an in-memory
+**`EvalCache`** of all flags, segments, variants, constraints, distributions,
+and tags — pre-parsed and ready for fast evaluation. Keeping the cache in
+memory means evaluation never touches the database on the request path; the
+database is only a source of truth for reloads.
+
+
+- **Refresh** — the cache reloads periodically (default every **3s**, via
+  `FLAGR_EVALCACHE_REFRESHINTERVAL`).
+- **Snapshot short-circuit** — the reload skips work when no new
+  `flag_snapshot` rows exist, because every mutation handler that changes
+  evaluation data also creates a snapshot.
+- **Version endpoint** — `GET /api/v1/flags/snapshots/max_id` returns the
+  current max `flag_snapshot` id, a monotonically increasing version counter
+  for the entire flag configuration. External caches (CDN, sidecar proxies,
+  app-level caches) can poll this single endpoint and invalidate when the value
+  changes — far cheaper than polling individual flag records.
+
+### Flagr Manager
+
+The CRUD gateway. All flag mutations happen here — create a flag, edit a
+segment, reorder, change a distribution. Every mutation flows through the
+Manager, which writes to the database and appends a `flag_snapshot` row. That
+snapshot is what the Evaluator watches to know when to reload.
+
+### Flagr Metrics
+
+Evaluation is only half the story — to measure impact you need to record *what
+happened*. Evaluation results and client-reported exposures
+(`POST /api/v1/exposures`) flow through the same **data recorders** when
+per-flag `dataRecordsEnabled` is on. Recording is **asynchronous** and
+fan-out, so a slow Kafka broker never stalls the eval response.
+
+- **Streaming recorders** — Kafka, AWS Kinesis, Google Pub/Sub (same wire
+  format for eval and exposure rows).
+- **Datar** — built-in eval-only aggregate; skips exposure rows.
+- **Combine** — set `FLAGR_RECORDER_TYPE` to a comma-separated list
+  (e.g. `kafka,datar`).
+
+See [Data Recorders & A/B Analysis](flagr_eval_exposure_pipeline.md).
 
 ![Flagr Architecture](images/flagr_arch.png)
 
 ## Related documentation
 
-- [Use Cases](flagr_use_cases.md) — how to instrument apps for flags, experiments, and dynamic config
+- [Use Cases](flagr_use_cases.md) — instrument apps for flags, experiments, dynamic config
 - [Exposure Logging](flagr_exposure.md) and [Data Recorders & A/B Analysis](flagr_eval_exposure_pipeline.md) — impressions and pipeline analytics
 - [Datar](flagr_datar.md) — optional built-in eval counters
 - [Environment Variables](flagr_env.md) — deployment and recorder configuration
-

--- a/docs/flagr_use_cases.md
+++ b/docs/flagr_use_cases.md
@@ -33,13 +33,34 @@ flag:
 evaluation_result = flagr.postEvaluation(entity)
 
 if (evaluation_result.variantKey == "on") {
-    // do something new and amazing here
+    // feature is on for this entity
 } else {
-    // do the current boring stuff
+    // feature is off (variantKey is empty, or the flag is disabled)
 }
 ```
 
-A typical feature flag in the Flagr UI:
+### The `enabled` toggle (simplest boolean flag)
+
+The simplest feature flag needs no variants at all. Every flag has a top-level
+`enabled` boolean, toggled from the UI's status switch or via
+`PUT /api/v1/flags/{flagID}/enabled`:
+
+```bash
+curl -X PUT "http://flagr:18000/api/v1/flags/1/enabled" \
+  -H 'Content-Type: application/json' \
+  -d '{"enabled": false}'
+```
+
+When `enabled` is `false`, the evaluator returns a **blank result** immediately —
+no `variantKey`, no segment matching, no rollout. It short-circuits before any
+segment logic runs. This is the kill switch: flip one boolean, and every
+evaluation of that flag returns nothing. No variants or segments to configure.
+
+### The `on`/`off` variant pattern (targeted rollouts)
+
+When you need *targeted* control — on for some users, off for others — use two
+variants (`on`/`off`) with a segment and distribution instead of the `enabled`
+toggle. The flag stays `enabled: true`; the distribution decides who gets `on`:
 
 ```
 Variants
@@ -55,6 +76,12 @@ Segment
 ```
 
 ![feature flagging setting demo](/images/demo_ff.png)
+
+| Pattern | When to use | How it works |
+|---------|-------------|--------------|
+| `enabled` toggle | Global kill switch — on or off for everyone | `PUT /flags/{id}/enabled` → evaluator returns blank when `false` |
+| `on`/`off` variants | Targeted rollout — on for a specific audience | Flag stays enabled; segment + distribution decide who gets `on` |
+
 
 ## Experimenting — A/B testing
 

--- a/docs/flagr_use_cases.md
+++ b/docs/flagr_use_cases.md
@@ -97,13 +97,13 @@ the code the same way and branch on the assigned variant:
 evaluation_result = flagr.postEvaluation(entity)
 
 if (evaluation_result.variantKey == "treatment1") {
-    // do the treatment 1 experience
+    // Treatment 1: show the new single-page checkout
 } else if (evaluation_result.variantKey == "treatment2") {
-    // do the treatment 2 experience
+    // Treatment 2: show the new accordion checkout
 } else if (evaluation_result.variantKey == "treatment3") {
-    // do the treatment 3 experience
+    // Treatment 3: show the new one-click checkout
 } else {
-    // do the control experience
+    // Control: show the current production checkout (the baseline)
 }
 ```
 

--- a/docs/flagr_use_cases.md
+++ b/docs/flagr_use_cases.md
@@ -39,28 +39,11 @@ if (evaluation_result.variantKey == "on") {
 }
 ```
 
-### The `enabled` toggle (simplest boolean flag)
+### The simple boolean flag (a starting template)
 
-The simplest feature flag needs no variants at all. Every flag has a top-level
-`enabled` boolean, toggled from the UI's status switch or via
-`PUT /api/v1/flags/{flagID}/enabled`:
-
-```bash
-curl -X PUT "http://flagr:18000/api/v1/flags/1/enabled" \
-  -H 'Content-Type: application/json' \
-  -d '{"enabled": false}'
-```
-
-When `enabled` is `false`, the evaluator returns a **blank result** immediately —
-no `variantKey`, no segment matching, no rollout. It short-circuits before any
-segment logic runs. This is the kill switch: flip one boolean, and every
-evaluation of that flag returns nothing. No variants or segments to configure.
-
-### The `on`/`off` variant pattern (targeted rollouts)
-
-When you need *targeted* control — on for some users, off for others — use two
-variants (`on`/`off`) with a segment and distribution instead of the `enabled`
-toggle. The flag stays `enabled: true`; the distribution decides who gets `on`:
+A simple boolean flag is the template most teams start with: two variants
+(`on`/`off`) and a single segment distributing 100% to `on`. It answers the
+question "is this feature on?" — nothing more.
 
 ```
 Variants
@@ -68,19 +51,32 @@ Variants
   - off
 
 Segment
-  - Constraints (targeted audience, e.g. state == "CA")
+  - Constraints: none (everyone)
   - Rollout Percent: 100%
   - Distribution
     - on: 100%
     - off: 0%
 ```
 
-![feature flagging setting demo](/images/demo_ff.png)
+This is just a convention, not a special flag type. The same flag can grow
+richer as your needs evolve — without changing your application code:
 
-| Pattern | When to use | How it works |
-|---------|-------------|--------------|
-| `enabled` toggle | Global kill switch — on or off for everyone | `PUT /flags/{id}/enabled` → evaluator returns blank when `false` |
-| `on`/`off` variants | Targeted rollout — on for a specific audience | Flag stays enabled; segment + distribution decide who gets `on` |
+- **Target a specific audience** — add constraints to the segment
+  (`state == "CA"`, `tier == "beta"`). Now `on` reaches only California users.
+- **Roll out gradually** — lower the rollout percent to 10%, then 50%, then
+  100%. Same flag, same variants, wider audience over time.
+- **Run an experiment** — add more variants (`treatment1`, `treatment2`) and
+  split the distribution (`33/33/34`). The boolean flag becomes an A/B test.
+- **Serve dynamic config** — attach JSON to each variant
+  (`{"color": "#42b983"}`). The flag now carries configuration, not just on/off.
+
+Every flag also has a top-level `enabled` toggle — the global kill switch.
+When `enabled` is `false`, the evaluator returns a blank result immediately,
+short-circuiting before any segment logic runs (`PUT /api/v1/flags/{id}/enabled`
+or the UI status switch). Use it to turn off the entire flag regardless of
+segments or distributions.
+
+![feature flagging setting demo](/images/demo_ff.png)
 
 
 ## Experimenting — A/B testing

--- a/docs/flagr_use_cases.md
+++ b/docs/flagr_use_cases.md
@@ -26,19 +26,6 @@ first, then a single region, then everyone. The key property is that *deploy*
 and *release* become independent — you can ship code to production hours
 before any user sees it.
 
-Given an entity (user, request, or cookie), Flagr evaluates it against the
-flag:
-
-```js
-evaluation_result = flagr.postEvaluation(entity)
-
-if (evaluation_result.variantKey == "on") {
-    // feature is on for this entity
-} else {
-    // feature is off (variantKey is empty, or the flag is disabled)
-}
-```
-
 ### The simple boolean flag (a starting template)
 
 A simple boolean flag is the template most teams start with: two variants
@@ -58,6 +45,19 @@ Segment
     - off: 0%
 ```
 
+Given an entity (user, request, or cookie), your application evaluates the
+flag and branches on the assigned variant:
+
+```js
+evaluation_result = flagr.postEvaluation(entity)
+
+if (evaluation_result.variantKey == "on") {
+    // feature is on for this entity
+} else {
+    // feature is off (variantKey is empty, or the flag is disabled)
+}
+```
+
 This is just a convention, not a special flag type. The same flag can grow
 richer as your needs evolve — without changing your application code:
 
@@ -65,19 +65,18 @@ richer as your needs evolve — without changing your application code:
   (`state == "CA"`, `tier == "beta"`). Now `on` reaches only California users.
 - **Roll out gradually** — lower the rollout percent to 10%, then 50%, then
   100%. Same flag, same variants, wider audience over time.
-- **Run an experiment** — add more variants (`treatment1`, `treatment2`) and
-  split the distribution (`33/33/34`). The boolean flag becomes an A/B test.
+- **Run an experiment** — add more variants and split the distribution
+  (`33/33/34`). The boolean flag becomes an A/B test.
 - **Serve dynamic config** — attach JSON to each variant
   (`{"color": "#42b983"}`). The flag now carries configuration, not just on/off.
 
-Every flag also has a top-level `enabled` toggle — the global kill switch.
-When `enabled` is `false`, the evaluator returns a blank result immediately,
-short-circuiting before any segment logic runs (`PUT /api/v1/flags/{id}/enabled`
-or the UI status switch). Use it to turn off the entire flag regardless of
-segments or distributions.
+Every flag also has a top-level `enabled` toggle — separate from the variant
+pattern above. When `enabled` is `false`, the evaluator returns a blank result
+immediately, short-circuiting before any segment logic runs
+(`PUT /api/v1/flags/{id}/enabled` or the UI status switch). Use it as a global
+kill switch to turn off the entire flag regardless of segments or distributions.
 
 ![feature flagging setting demo](/images/demo_ff.png)
-
 
 ## Experimenting — A/B testing
 

--- a/docs/flagr_use_cases.md
+++ b/docs/flagr_use_cases.md
@@ -96,14 +96,14 @@ the code the same way and branch on the assigned variant:
 ```js
 evaluation_result = flagr.postEvaluation(entity)
 
-if (evaluation_result.variantKey == "treatment1") {
+if (evaluation_result.variantKey == "control") {
+    // Control: show the current production checkout (the baseline)
+} else if (evaluation_result.variantKey == "treatment1") {
     // Treatment 1: show the new single-page checkout
 } else if (evaluation_result.variantKey == "treatment2") {
     // Treatment 2: show the new accordion checkout
 } else if (evaluation_result.variantKey == "treatment3") {
     // Treatment 3: show the new one-click checkout
-} else {
-    // Control: show the current production checkout (the baseline)
 }
 ```
 

--- a/docs/flagr_use_cases.md
+++ b/docs/flagr_use_cases.md
@@ -1,25 +1,45 @@
 # Flagr Use Cases
 
-**Feature flagging, A/B testing, and dynamic configuration** are all about delivering the experience to the right target audience,
-thus they share some components in the product design of Flagr. In fact, Flagr consolidates them together into the concept of
-a flag, and the code instrumentation looks similar among them.
+Feature flags, A/B tests, and dynamic configuration look like different
+problems — a kill switch, a marketing experiment, a runtime knob. But at the
+moment of decision, they all ask the same question: *given this entity, which
+experience should it get?* That is why Flagr consolidates them into one
+primitive — the **flag**. The difference between a feature flag and an
+experiment is not structural, it is operational: a feature flag cares about
+*who* is on, an experiment cares about *what they got* and *whether it
+mattered*. The instrumentation is identical; the analysis differs. This page
+shows the three patterns side by side so you can see how the same evaluation
+call serves all three.
 
+> **Note:** The pseudocode below uses the actual API response field names —
+> `variantID`, `variantKey`, and `variantAttachment` (camelCase), as returned
+> by `POST /evaluation`.
 
-## Feature Flagging
+## Feature flagging
 
-A common pattern for feature flagging is a binary on/off toggle. Most of them are kill switches, and sometimes one will have targeted audience of the feature flags. Following is a pseudocode example: given an entity (a user, a request, or a web cookie), Flagr evaluates the entity according to the flag setting.
+A feature flag is the simplest decision in software: should this code path
+run, or not? The most familiar shape is the **kill switch** — a globally
+visible "off" you can throw the instant a deploy goes wrong, without
+redeploying or paging an engineer to roll back. But the same mechanism
+generalizes to **targeted rollouts**: turn a feature on for internal users
+first, then a single region, then everyone. The key property is that *deploy*
+and *release* become independent — you can ship code to production hours
+before any user sees it.
 
-```
-evaluation_result = flagr.post_evaluation( entity )
+Given an entity (user, request, or cookie), Flagr evaluates it against the
+flag:
 
-if (evaluation_result.variant_id == new_feature_on) {
-    // do something new and amazing here.
+```js
+evaluation_result = flagr.postEvaluation(entity)
+
+if (evaluation_result.variantKey == "on") {
+    // do something new and amazing here
 } else {
-    // do the current boring stuff.
+    // do the current boring stuff
 }
 ```
 
-And a typical feature flag can be configured from Flagr UI like:
+A typical feature flag in the Flagr UI:
 
 ```
 Variants
@@ -27,40 +47,46 @@ Variants
   - off
 
 Segment
-  - Constraints (depends on your targeted audience, e.g. state == "CA")
+  - Constraints (targeted audience, e.g. state == "CA")
   - Rollout Percent: 100%
   - Distribution
     - on: 100%
     - off: 0%
 ```
 
-UI setting example (frontend looks may iterate quickly):
 ![feature flagging setting demo](/images/demo_ff.png)
 
+## Experimenting — A/B testing
 
-## Experimenting - A/B testing
+A feature flag answers *on or off?* An experiment answers a harder question:
+*which of these is better?* To answer it you expose different variants to
+different slices of your audience and measure outcomes. Flagr's job is the
+exposure half — deterministic, sticky assignment so the same user always sees
+the same treatment. The measurement half (conversion rates, significance) is
+yours; Flagr emits the events but does not compute the verdict.
 
-If we want to run A/B testing experiments on several variants with a targeted audience,
-we may want to instrument the code to Flagr like the following pseudocode:
+To run an A/B test across several variants with a targeted audience, instrument
+the code the same way and branch on the assigned variant:
 
-```
-evaluation_result = flagr.post_evaluation( entity )
+```js
+evaluation_result = flagr.postEvaluation(entity)
 
-if (evaluation_result.variant_id == treatment1) {
+if (evaluation_result.variantKey == "treatment1") {
     // do the treatment 1 experience
-} else if (evaluation_result.variant_id == treatment2) {
+} else if (evaluation_result.variantKey == "treatment2") {
     // do the treatment 2 experience
-} else if (evaluation_result.variant_id == treatment3) {
+} else if (evaluation_result.variantKey == "treatment3") {
     // do the treatment 3 experience
 } else {
     // do the control experience
 }
 ```
 
-And a typical A/B testing flag can be configured from Flagr UI like the following:
+> **Warning:** Segment order matters. An entity falls into the **first**
+> segment whose constraints **all** match. List targeted segments before broad
+> ones.
 
-!> Multiple segments' order is important! Entities will fall
-into the **first** segment that match **all** the constraints of it.
+A typical A/B test flag in the UI:
 
 ```
 Variants
@@ -69,47 +95,61 @@ Variants
   - treatment2
   - treatment3
 
-Segment
+Segment                         // state == "CA"
   - Constraints (state == "CA")
   - Rollout Percent: 20%
   - Distribution
-    - control: 25%
+    - control:    25%
     - treatment1: 25%
     - treatment2: 25%
     - treatment3: 25%
-Segment
+
+Segment                         // state == "NY" AND age >= 21
   - Constraints (state == "NY" AND age >= 21)
   - Rollout Percent: 100%
   - Distribution
-    - control: 50%
-    - treatment1: 0%
+    - control:    50%
+    - treatment1:  0%
     - treatment2: 25%
     - treatment3: 25%
 ```
 
-UI setting example (frontend looks may iterate quickly):
 ![ab testing setting demo 1](/images/demo_exp1.png)
 ![ab testing setting demo 2](/images/demo_exp2.png)
 
-For **measuring experiment outcomes** (conversion rates, etc.), assignment from `POST /evaluation` is not enough—you need **impression** events. Use [Exposure Logging](flagr_exposure.md) when the user sees the treatment, then [Data Recorders & A/B Analysis](flagr_eval_exposure_pipeline.md) (or your own consumer on Kinesis/Pub/Sub) to build denominators and join to business metrics. For quick **eval volume** only, see [Datar](flagr_datar.md).
+### Measuring experiment outcomes
 
-## Dynamic Configuration
+Assignment from `POST /evaluation` is **not** enough to measure conversion —
+you need **impression** events. Use
+[Exposure Logging](flagr_exposure.md) when the user actually sees the
+treatment, then
+[Data Recorders & A/B Analysis](flagr_eval_exposure_pipeline.md) (or your own
+consumer on Kafka/Kinesis/Pub/Sub) to build denominators and join to business
+metrics. For quick **eval volume** only, see [Datar](flagr_datar.md).
 
-One can also leverage the **Variant Attachment** to run dynamic configuration, by supplying a valid JSON object attachment.
+## Dynamic configuration
 
-!> Before [v1.1.3](https://github.com/openflagr/flagr/releases/tag/1.1.3), only **string:string** key:value pairs were supported inside the JSON object attachment.
+Sometimes the decision isn't *which experience* but *what value* — the
+threshold for a cache, the copy on a button, the timeout for a retry. You
+could redeploy for each change, or you can let the variant carry the value.
+A variant's **Attachment** is an arbitrary JSON object delivered alongside the
+`variantKey`, so your code reads a configuration value the same way it reads
+an assignment — no second fetch, no separate config service, no restart.
 
-For example, the color_hex of green variant can be dynamically configured:
+Use a variant's **Attachment** (an arbitrary JSON object) to carry dynamic
+configuration:
 
-```
-evaluation_result = flagr.post_evaluation( entity )
+```js
+evaluation_result = flagr.postEvaluation(entity)
 green_color_hex = evaluation_result.variantAttachment["color_hex"]
 ```
+
+A typical dynamic-config flag:
 
 ```
 Variants
   - green
-    - attachment: {"color_hex": "#42b983"} OR {"color_hex": "#008000"}
+    - attachment: {"color_hex": "#42b983"}   // or {"color_hex": "#008000"}
   - red
     - attachment: {"color_hex": "#ff0000"}
 
@@ -122,3 +162,9 @@ Segment
 ```
 
 ![dynamic configuration demo](/images/demo_dynamic_configuration.png)
+
+> **Note:** Prior to [v1.1.3](https://github.com/openflagr/flagr/releases/tag/1.1.3),
+> attachments supported only `string:string` key/value pairs. Current Flagr
+> stores attachments as `map[string]any`, so arbitrary JSON values are
+> supported. (The historical boundary is documented in the GitHub release
+> notes; the in-repo `CHANGELOG.md` links there.)

--- a/docs/flagr_use_cases.md
+++ b/docs/flagr_use_cases.md
@@ -65,6 +65,31 @@ exposure half — deterministic, sticky assignment so the same user always sees
 the same treatment. The measurement half (conversion rates, significance) is
 yours; Flagr emits the events but does not compute the verdict.
 
+### Variants in experiments: control and treatment
+
+The names `control` and `treatment` are **convention, not a Flagr contract**.
+Flagr treats every variant the same — `control` is no more special than `on`,
+`green`, or `version_b`. The convention comes from experimentation methodology:
+
+- **Control** — the *baseline* experience. Usually the current production
+  behavior. This is what you compare against. If your experiment is "new
+  checkout button," control is the existing button.
+- **Treatment** — the *change* you are testing. There can be one or many:
+  `treatment1`, `treatment2`, `treatment3`. Each is a distinct alternative
+  you're measuring against the control.
+
+The distinction matters in your **analytics**, not in Flagr. When you group
+exposure rows by `variantKey` in your warehouse, the control group is your
+baseline conversion rate; each treatment's rate is compared against it to
+measure lift. If you have no control (e.g. testing two brand-new designs),
+pick one variant as the reference — but the convention of naming a baseline
+"control" makes the analysis self-documenting.
+
+> **Note:** Flagr does not enforce that a flag has a control variant. You can
+> run a flag with only treatments, or with no variant named "control" at all.
+> The names are for you and your analytics pipeline; Flagr only assigns and
+> records the `variantKey` you configured.
+
 To run an A/B test across several variants with a targeted audience, instrument
 the code the same way and branch on the assigned variant:
 

--- a/docs/home.md
+++ b/docs/home.md
@@ -1,28 +1,50 @@
 # Get Started
 
-Flagr is an open source Go service that delivers the right experience to the right entity and monitors the impact. It provides **feature flags**, **experimentation (A/B testing)**, and **dynamic configuration** — all behind clear swagger REST APIs for flag management and evaluation.
+Shipping software is a constant negotiation between **velocity** and
+**risk**. You want to move fast, but you also need to decouple *deploy* from
+*release* — to turn a feature on for one user, a thousand users, or nobody,
+without redeploying. You need to **experiment**: to learn which of two
+experiences performs better, with a denominator you can trust. And you need
+**dynamic configuration** — change a color, a copy string, a timeout — without
+a code change or a restart.
 
-For a deeper introduction, see the [Flagr Overview](flagr_overview).
+These three problems — feature flagging, A/B testing, and dynamic
+configuration — are usually solved by three different tools. Flagr solves all
+three with one primitive: the **flag**. A flag is a decision point in your
+code. Behind that decision sits an evaluation engine that looks at *who* is
+asking and decides *what* they get. The same engine that toggles a kill switch
+also splits traffic between variants and serves per-variant JSON attachments.
+
+Flagr is an open-source Go service that delivers the right experience to the
+right entity and monitors the impact. It exposes that evaluation engine behind
+a Swagger-documented REST API for flag management and evaluation — so your
+application code stays thin (`POST /evaluation`, read the `variantKey`),
+while operators configure targeting, distribution, and rollout from a UI or
+as code.
+
+New to Flagr? Start with the [Overview](flagr_overview) for core concepts.
 
 ## Documentation map
 
-| If you want to… | Start here |
-|-----------------|------------|
+| Goal | Read |
+|------|-----|
 | Learn concepts (flags, segments, rollout) | [Overview](flagr_overview) |
 | See code patterns for flags / A/B / config | [Use Cases](flagr_use_cases) |
 | Configure the server (DB, auth, recorders) | [Environment Variables](flagr_env) |
 | Run flags from Git (no DB) | [JSON Flag Source](flagr_json_flag_spec) |
 | Log impressions after eval (`POST /exposures`) | [Exposure Logging](flagr_exposure) |
-| Ship eval + exposure to a data recorder and analyze A/B | [Data Recorders & A/B Analysis](flagr_eval_exposure_pipeline) |
+| Ship eval + exposure to a recorder and analyze A/B | [Data Recorders & A/B Analysis](flagr_eval_exposure_pipeline) |
 | Quick eval counts inside Flagr (no pipeline) | [Datar Analytics](flagr_datar) |
 | Test evaluation in the UI | [Debug Console](flagr_debugging) |
 | Webhooks on flag changes | [Notifications](flagr_notifications) |
 | REST API details | [API Reference](https://openflagr.github.io/flagr/api_docs) |
 
-**Event recording:** [Exposure](flagr_exposure) (API) → [Data Recorders & A/B Analysis](flagr_eval_exposure_pipeline) → [Datar](flagr_datar) (built-in eval-only aggregates). Env vars: [Data record destinations](flagr_env?id=data-record-destinations).
+**Event-recording path:** [Exposure](flagr_exposure) (API) →
+[Data Recorders & A/B Analysis](flagr_eval_exposure_pipeline) →
+[Datar](flagr_datar) (built-in eval-only aggregates). Recorder env vars:
+[Data record destinations](flagr_env?id=data-record-destinations).
 
-
-## What can Flagr do?
+## What Flagr can do
 
 | Capability | Highlights |
 |------------|------------|
@@ -48,7 +70,9 @@ docker run -it -p 18000:18000 ghcr.io/openflagr/flagr
 open localhost:18000
 ```
 
-Or try the hosted demo at [https://try-flagr.onrender.com](https://try-flagr.onrender.com) (cold starts may take a moment):
+Or try the hosted demo at
+[https://try-flagr.onrender.com](https://try-flagr.onrender.com)
+(cold starts may take a moment):
 
 ```bash
 curl --request POST \
@@ -67,7 +91,7 @@ curl --request POST \
 
 ### Prerequisites
 
-- **Go** 1.24+
+- **Go** 1.24+ (CI builds with Go 1.26; see `go.mod`)
 - **Node** 20+ (for UI development)
 - **Make**
 
@@ -77,17 +101,11 @@ curl --request POST \
 git clone https://github.com/openflagr/flagr.git
 cd flagr
 
-# Build the Go server binary
-make build
+make build        # Build the Go server binary (./flagr)
+make start        # Backend (:18000) + frontend dev server (:8080) in parallel
 
-# Start backend (:18000) + frontend dev server (:8080) in parallel
-make start
-
-# Or run just the pre-built backend
-make run
-
-# Or run just the UI dev server (proxies /api/v1 to :18000)
-make run_ui
+make run          # Run the pre-built backend only
+make run_ui       # Run the UI dev server only (proxies /api/v1 to :18000)
 ```
 
 After Go code changes, rebuild and restart in one step:
@@ -96,7 +114,11 @@ After Go code changes, rebuild and restart in one step:
 make rebuild-run    # build → stop-ui → start
 ```
 
-Frontend-only development: run `npm run dev` in `browser/flagr-ui/` — Vite proxies `/api/v1` to `:18000` and hot-reloads on save.
+> **Note:** `make stop-ui` kills processes bound to `:18000` and `:8080` (via
+> `lsof -ti:<port>`), so it never touches processes from other projects.
+
+Frontend-only development: run `npm run dev` in `browser/flagr-ui/` — Vite
+proxies `/api/v1` to `:18000` and hot-reloads on save.
 
 ## Testing
 
@@ -104,7 +126,7 @@ Flagr has three kinds of tests, each serving a different purpose.
 
 ### Unit tests
 
-Run the Go unit tests (no external services required):
+Go unit tests for `pkg/` — no external services required:
 
 ```bash
 make test
@@ -116,10 +138,13 @@ Or directly:
 go test ./pkg/...
 ```
 
-### E2E tests (Flagr UI)
+> **Note:** `make test` also runs `verifiers` first (golangci-lint + Swagger
+> validation). `go test ./pkg/...` skips that prerequisite.
 
-Playwright-based end-to-end tests for the Vue 3 UI. Builds the Go
-server, starts the backend and UI servers, runs Playwright, then cleans up:
+### E2E tests (UI)
+
+Playwright end-to-end tests for the Vue 3 UI. Builds the Go server, starts the
+backend and UI servers, runs Playwright, then cleans up:
 
 ```bash
 make test-e2e
@@ -127,28 +152,25 @@ make test-e2e
 
 ### Integration tests (API, multi-DB)
 
-HTTP-level integration tests covering all CRUD and eval endpoints.
-Seeds ~50 realistic flags across all 12 constraint operators.
+HTTP-level integration tests covering all CRUD and eval endpoints. Seeds ~48
+realistic flags across all 12 constraint operators.
 
-**Local mode** — SQLite `:memory:`, auto-starts server on random port:
+**Local mode** — SQLite `:memory:`, auto-starts a server on a random port:
 
 ```bash
 make test-integration
 ```
 
-**Docker Compose mode** — runs the same test suite against 6 flagr
-instances (SQLite, MySQL, MySQL 8, PostgreSQL 9, PostgreSQL 13,
-checkr/flagr):
+**Docker Compose mode** — runs the same suite against 6 Flagr instances
+(SQLite, MySQL, MySQL 8, PostgreSQL 9, PostgreSQL 13, checkr/flagr):
 
 ```bash
 cd integration_tests && make test
 ```
 
-To run against a single Docker Compose instance:
-
-```bash
-cd integration_tests && make test-instance INSTANCE=flagr_with_mysql
-```
+> **Note:** CI runs `make test-and-bench` (tests + benchmarks against the same
+> instances). Other compose targets: `make bench` (benchmarks only),
+> `make retest` (tear down then re-run).
 
 **HTTP eval benchmarks** — measures end-to-end eval latency through HTTP:
 
@@ -158,17 +180,18 @@ make bench-integration
 
 ## Deploy
 
-We recommend using the `ghcr.io/openflagr/flagr` image directly and configuring everything through environment variables. See [Server Configuration](flagr_env) for the full list.
+Use the `ghcr.io/openflagr/flagr` image directly and configure everything
+through environment variables. See
+[Server Configuration](flagr_env) for the full list.
 
 ```bash
-# Set env variables. For example,
 export HOST=0.0.0.0
 export PORT=18000
 export FLAGR_DB_DBDRIVER=mysql
 export FLAGR_DB_DBCONNECTIONSTR=root:@tcp(127.0.0.1:18100)/flagr?parseTime=true
 
-# Run the docker image. Ideally, the deployment will be handled by Kubernetes or Mesos.
 docker run -it -p 18000:18000 ghcr.io/openflagr/flagr
 ```
 
-For GitOps workflows (flags-as-code, eval-only mode), see the [JSON Flag Source](flagr_json_flag_spec) guide.
+For GitOps workflows (flags-as-code, eval-only mode), see the
+[JSON Flag Source](flagr_json_flag_spec) guide.

--- a/pkg/config/env.go
+++ b/pkg/config/env.go
@@ -205,7 +205,7 @@ var Config = struct {
 	*/
 	JWTAuthEnabled              bool     `env:"FLAGR_JWT_AUTH_ENABLED" envDefault:"false"`
 	JWTAuthDebug                bool     `env:"FLAGR_JWT_AUTH_DEBUG" envDefault:"false"`
-	JWTAuthPrefixWhitelistPaths []string `env:"FLAGR_JWT_AUTH_WHITELIST_PATHS" envDefault:"/api/v1/health,/api/v1/evaluation,/static" envSeparator:","`
+	JWTAuthPrefixWhitelistPaths []string `env:"FLAGR_JWT_AUTH_WHITELIST_PATHS" envDefault:"/api/v1/health,/api/v1/evaluation,/api/v1/exposures,/static" envSeparator:","`
 	JWTAuthExactWhitelistPaths  []string `env:"FLAGR_JWT_AUTH_EXACT_WHITELIST_PATHS" envDefault:",/" envSeparator:","`
 	JWTAuthCookieTokenName      string   `env:"FLAGR_JWT_AUTH_COOKIE_TOKEN_NAME" envDefault:"access_token"`
 	JWTAuthSecret               string   `env:"FLAGR_JWT_AUTH_SECRET" envDefault:""`
@@ -233,7 +233,7 @@ var Config = struct {
 	BasicAuthEnabled              bool     `env:"FLAGR_BASIC_AUTH_ENABLED" envDefault:"false"`
 	BasicAuthUsername             string   `env:"FLAGR_BASIC_AUTH_USERNAME" envDefault:""`
 	BasicAuthPassword             string   `env:"FLAGR_BASIC_AUTH_PASSWORD" envDefault:""`
-	BasicAuthPrefixWhitelistPaths []string `env:"FLAGR_BASIC_AUTH_WHITELIST_PATHS" envDefault:"/api/v1/health,/api/v1/flags,/api/v1/evaluation" envSeparator:","`
+	BasicAuthPrefixWhitelistPaths []string `env:"FLAGR_BASIC_AUTH_WHITELIST_PATHS" envDefault:"/api/v1/health,/api/v1/flags,/api/v1/evaluation,/api/v1/exposures" envSeparator:","`
 	BasicAuthExactWhitelistPaths  []string `env:"FLAGR_BASIC_AUTH_EXACT_WHITELIST_PATHS" envDefault:"" envSeparator:","`
 
 	// ===== Notification - Global Settings =====


### PR DESCRIPTION
## Description

Refactors all 10 `docs/*.md`, `README.md`, and `AGENTS.md` for clarity, accuracy, and narrative context. Every behavioral claim was verified against the codebase (`pkg/`, `swagger_gen/`, `cmd/`, tests, configs) before editing.

Also includes one code change: opening `/exposures` by default to match `/evaluation` auth parity (see below).

**Accuracy corrections (code-grounded):**

| Doc | Fix |
|-----|-----|
| `home.md` | Removed non-existent `make test-instance` target; seed count → ~48 |
| `overview.md` | Hash is CRC32 only (not "CRC32, MD5"); clarified rollout bucket-sub-range; "Variant Attachment" = `Variant.Attachment` field |
| `use_cases.md` | Pseudocode `variant_id` → `variantID`/`variantKey`/`variantAttachment` (camelCase, matches API) |
| `debugging.md` | Console wraps both `/evaluation` and `/evaluation/batch`; `segmentDebugLogs` has only `msg`+`segmentID` |
| `env.md` | Basic-auth note clarified as default-whitelist behavior; documented actual defaults |
| `json_flag_spec.md` | Segment `Rank` default 999 is CRUD-API-only (JSON loader leaves `0`); `Tag.Value` not validated by `ValidateFlags` |
| `notifications.md` | Removed fabricated `EntityType` field; metric has 3 tags (not 4); tag add/remove fires `create`/`delete` |
| `exposure.md` | Auth section rewritten for new open-by-default parity (see code change) |
| `eval_exposure_pipeline.md` | Disabled/not-found early-return before recording; `PARTITION_KEY_ENABLED` defaults `true` |
| `datar.md` | Resource numbers flagged as indicative (no benchmarks); added `segment_id=0` exclusion note |
| `README.md` | Simpler, humbler intro; architecture prose stripped of internal symbol names; trimmed duplicate detail |
| `AGENTS.md` | Frontend key-code list trimmed 11→4; added missing `exposure.go`/`data_recorder*.go`; merged redundant Workflows section |

**Structural:** consistent H1/H2/H3, tables for reference data, active voice, callouts (`Note`/`Warning`) where behavior is non-obvious. Added narrative context (the "why" behind each concept) without duplicating across docs. All internal links and sidebar anchors verified intact.

### Code change: `/exposures` auth parity

Added `/api/v1/exposures` to the default prefix whitelists for both JWT and Basic auth in `pkg/config/env.go`, so `POST /exposures` is open by default — matching `POST /evaluation`. Both are client-side endpoints called from browsers; the asymmetry was a footgun for the A/B loop on auth-enabled deployments. The doc flags the write-endpoint integrity tradeoff for deployments that need impression authenticity.

## Motivation and Context

The docs had accumulated factual inaccuracies relative to the current code and were reference-dense without explaining *why* each concept exists. The `/exposures` auth asymmetry broke the exposure-logging use case for any auth-enabled deployment that hadn't manually whitelisted the endpoint. This grounds every doc claim in code, fixes the inaccuracies, adds the motivation behind the mechanics, and fixes the auth parity.

## How Has This Been Tested?

- 10 parallel read-only verification agents grounded each doc against the codebase with `file:line` evidence before edits.
- Internal links, sidebar anchors, and markdown formatting verified after each edit.
- `go build ./pkg/config/...` and `go test ./pkg/config/...` — pass.
- `go test ./pkg/handler/...` — pass (covers exposure + auth middleware).

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

> Changes auth defaults for `/exposures` from protected to open — opt-in by removal from whitelist, same as `/evaluation`.

## Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.