### PR TITLE
docs(env): clarify that FLAGR_JWT_AUTH_SECRET holds RSA public key for RS256

### DIFF
--- a/docs/flagr_env.md
+++ b/docs/flagr_env.md
@@ -84,7 +84,7 @@ the full list):
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `FLAGR_JWT_AUTH_ENABLED` | `false` | Enable JWT auth |
-| `FLAGR_JWT_AUTH_SECRET` | — | Signing secret (HS256/HS512) |
+| `FLAGR_JWT_AUTH_SECRET` | — | HMAC signing secret (`HS256`/`HS512`) or PEM-encoded RSA public key (`RS256`) |
 | `FLAGR_JWT_AUTH_SIGNING_METHOD` | `HS256` | `HS256`, `HS512`, or `RS256` |
 | `FLAGR_JWT_AUTH_WHITELIST_PATHS` | `/api/v1/health,/api/v1/evaluation,/api/v1/exposures,/static` | Prefix-whitelisted paths (open when JWT auth is on) |
 | `FLAGR_JWT_AUTH_EXACT_WHITELIST_PATHS` | `/,` | Exact-whitelisted paths |


### PR DESCRIPTION
## Description

`FLAGR_JWT_AUTH_SECRET` is used differently depending on `FLAGR_JWT_AUTH_SIGNING_METHOD`:

- `HS256` / `HS512`: treated as the HMAC secret
- `RS256`: parsed as a PEM-encoded RSA **public key** via `jwt.ParseRSAPublicKeyFromPEM`

The previous description "Signing secret (HS256/HS512)" was incomplete and misleading for RS256 users.

This PR updates the table in `docs/flagr_env.md` to accurately describe both cases.

## How Has This Been Tested?

Existing unit tests in `pkg/config/middleware_test.go` cover the RS256 path (they set `JWTAuthSecret` to a PEM public key and verify a valid RS256 token is accepted). Tests were re-run as part of this change and pass.

## Checklist

- [x] Documentation updated
- [x] Relevant tests pass