### PR TITLE
Prepare 1.2.0 release

### DIFF
--- a/browser/flagr-ui/package-lock.json
+++ b/browser/flagr-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "flagr-ui",
-    "version": "1.1.20",
+    "version": "1.2.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "flagr-ui",
-            "version": "1.1.20",
+            "version": "1.2.0",
             "dependencies": {
                 "@element-plus/icons-vue": "^2.3.1",
                 "@vscode/markdown-it-katex": "^1.1.2",

--- a/browser/flagr-ui/package.json
+++ b/browser/flagr-ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "flagr-ui",
-    "version": "1.1.20",
+    "version": "1.2.0",
     "private": true,
     "scripts": {
         "dev": "vite",

--- a/docs/api_docs/bundle.yaml
+++ b/docs/api_docs/bundle.yaml
@@ -4,7 +4,7 @@ info:
     Flagr is a feature flagging, A/B testing and dynamic configuration
     microservice. The base path for all the APIs is "/api/v1".
   title: Flagr
-  version: 1.1.20
+  version: 1.2.0
 tags:
   - name: flag
     description: Everything about the flag

--- a/swagger/index.yaml
+++ b/swagger/index.yaml
@@ -5,7 +5,7 @@ info:
     Flagr is a feature flagging, A/B testing and dynamic configuration microservice.
     The base path for all the APIs is "/api/v1".
   title: Flagr
-  version: 1.1.20
+  version: 1.2.0
 tags:
   - name: flag
     description: Everything about the flag

--- a/swagger_gen/restapi/doc.go
+++ b/swagger_gen/restapi/doc.go
@@ -8,7 +8,7 @@
 //	  http
 //	Host: localhost
 //	BasePath: /api/v1
-//	Version: 1.1.20
+//	Version: 1.2.0
 //
 //	Consumes:
 //	  - application/json

--- a/swagger_gen/restapi/embedded_spec.go
+++ b/swagger_gen/restapi/embedded_spec.go
@@ -28,7 +28,7 @@ func init() {
   "info": {
     "description": "Flagr is a feature flagging, A/B testing and dynamic configuration microservice. The base path for all the APIs is \"/api/v1\".\n",
     "title": "Flagr",
-    "version": "1.1.20"
+    "version": "1.2.0"
   },
   "basePath": "/api/v1",
   "paths": {
@@ -2511,7 +2511,7 @@ func init() {
   "info": {
     "description": "Flagr is a feature flagging, A/B testing and dynamic configuration microservice. The base path for all the APIs is \"/api/v1\".\n",
     "title": "Flagr",
-    "version": "1.1.20"
+    "version": "1.2.0"
   },
   "basePath": "/api/v1",
   "paths": {


### PR DESCRIPTION
## Description

Bump release version from **1.1.20** to **1.2.0** across OpenAPI spec, generated swagger, and UI package metadata — same process as #652 and #634.

**Files touched:**
- `swagger/index.yaml` (source of truth for API version)
- `docs/api_docs/bundle.yaml` (via `make gen`)
- `swagger_gen/restapi/doc.go`, `embedded_spec.go` (via `make gen`)
- `browser/flagr-ui/package.json`, `package-lock.json`

## Motivation and Context

Ship accumulated features since 1.1.20 (Feb 2026) as a **minor** release. Themes since `cb84e8cb`: exposure logging, GitOps JSON flags, Datar recorder, Vue 3 UI, eval performance, Go 1.26 / `cmd/` layout.

After merge: tag `1.2.0` and publish GitHub Release (Docker CD picks up tag).

## How Has This Been Tested?

- `make gen`
- `make verify_swagger_nochange`

## Types of changes

- [x] Breaking change (fix or feature that would cause existing functionality to change) — release train; breaking items landed in prior PRs

## Checklist:

- [x] My code follows the code style of this project.
- [x] All new and existing tests passed. (`verify_swagger_nochange`)

---

### Suggested GitHub Release body (post-merge)

**Highlights (1.1.20 → 1.2.0)**
- Client exposure logging (`POST /exposures`) (#711)
- JSON GitOps — eval-only, auto-ID, `flagr-validate` (#699)
- Datar recorder + comma-separated `FLAGR_RECORDER_TYPE` (#692)
- UI: Vue 3 + Vite + Element Plus (#689, #707, #708)
- Faster eval / batch (#709), eval cache short-circuit (#686)
- Nested field constraints (#682)
- Go 1.26; `cmd/flagr-server` (#656, #705)

**Fixes:** duplicate create/restore (#703), security (#702, #697), EREG/NEREG (#683)

**Upgrade:** Vue 3 UI; refresh API clients; review GitOps / eval-only env docs.