### PR TITLE
fix(ui): restore distribution Edit dialog after clone/ASI regression

### DIFF
--- a/browser/flagr-ui/e2e/flag-detail.spec.js
+++ b/browser/flagr-ui/e2e/flag-detail.spec.js
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test'
-import { createFlagWithVariants, createFlag, deleteFlag, createSegment, createConstraint, createVariant, API, waitForSnapshot } from './helpers.js'
+import { createFlagWithVariants, createFlag, deleteFlag, createSegment, createConstraint, createVariant, API, waitForSnapshot, getFlag, putSegmentDistributions } from './helpers.js'
 
 test.describe('Flag detail page', () => {
   /** Set by each test, cleaned up in afterEach. */
@@ -370,26 +370,26 @@ test.describe('Flag detail page', () => {
 
   test('can edit distribution via dialog', async ({ page }) => {
     flag = await createFlagWithVariants()
-    await createSegment(flag.id, `dist-${Date.now()}`)
+    const segment = await createSegment(flag.id, `dist-${Date.now()}`)
+    const flagData = await getFlag(flag.id)
+    const controlVariant = flagData.variants.find(v => v.key === 'control')
+    expect(controlVariant).toBeTruthy()
+    await putSegmentDistributions(flag.id, segment.id, [
+      { variantKey: 'control', variantID: controlVariant.id, percent: 100, bitmap: '' },
+    ])
     await page.goto(`/#/flags/${flag.id}`)
     await expect(page.locator('input[data-testid="flag-key-input"]')).toBeVisible({ timeout: 10000 })
-    // Open the distribution edit dialog — use specific selector for the segment's Edit button
-    await page.locator('.seg-panel-dist button:has-text("Edit")').first().click()
+    await page.locator('[data-testid="edit-distribution-btn"]').first().click()
     await expect(page.locator('.el-dialog')).toBeVisible({ timeout: 5000 })
-    // Check the first variant checkbox
-    const checkbox = page.locator('.dist-variant-row .el-checkbox').first()
-    await checkbox.click()
-    // Set percentage to 100 via slider input
+    await expect(page.getByRole('heading', { name: 'Edit Distribution' })).toBeVisible()
+    await expect(page.locator('.dist-variant-row .el-checkbox').first()).toBeChecked({ timeout: 3000 })
     const sliderInput = page.locator('.dist-slider-row input[type="number"], .dist-slider-row .el-input__inner').first()
     await sliderInput.fill('100')
-    // Save
     await page.locator('.el-dialog .el-button--primary').click()
     await expect(page.locator('.el-message--success')).toBeVisible({ timeout: 5000 })
-    // Verify distribution persisted via API
-    const r = await page.request.get(`${API}/flags/${flag.id}`)
-    expect(r.ok()).toBeTruthy()
-    const updated = await r.json()
+    const updated = await getFlag(flag.id)
     expect(updated.segments[0].distributions.length).toBeGreaterThan(0)
+    expect(updated.segments[0].distributions[0].percent).toBe(100)
   })
 
   test('can add and delete tags via UI', async ({ page }) => {

--- a/browser/flagr-ui/e2e/helpers.js
+++ b/browser/flagr-ui/e2e/helpers.js
@@ -36,6 +36,22 @@ export async function createSegment(flagId, desc) {
   return r.json()
 }
 
+export async function getFlag(flagId) {
+  const r = await fetch(`${API}/flags/${flagId}`)
+  if (!r.ok) throw new Error(`getFlag(${flagId}) failed: ${r.status}`)
+  return r.json()
+}
+
+export async function putSegmentDistributions(flagId, segmentId, distributions) {
+  const r = await fetch(`${API}/flags/${flagId}/segments/${segmentId}/distributions`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ distributions }),
+  })
+  if (!r.ok) throw new Error(`putSegmentDistributions failed: ${r.status} ${await r.text()}`)
+  return r.json()
+}
+
 export async function createConstraint(flagId, segId) {
   const r = await fetch(`${API}/flags/${flagId}/segments/${segId}/constraints`, {
     method: 'POST', headers: { 'Content-Type': 'application/json' },

--- a/browser/flagr-ui/src/components/Flag.vue
+++ b/browser/flagr-ui/src/components/Flag.vue
@@ -141,6 +141,20 @@ function processVariant(variant) {
   }
 }
 
+function normalizeSegment(segment) {
+  if (!segment.constraints) segment.constraints = []
+  if (!segment.distributions) segment.distributions = []
+  return segment
+}
+
+function normalizeFlag(flag) {
+  flag.variants.forEach(v => processVariant(v))
+  for (const segment of flag.segments || []) {
+    normalizeSegment(segment)
+  }
+  return flag
+}
+
 export default {
   name: "flag",
   components: {
@@ -323,8 +337,7 @@ export default {
     createSegment() {
       Axios.post(`${API_URL}/flags/${this.flagId}/segments`, this.newSegment).then(
         response => {
-          const segment = response.data
-          segment.constraints = []
+          const segment = normalizeSegment(response.data)
           this.newSegment = { ...DEFAULT_SEGMENT }
           this.flag.segments = [...this.flag.segments, segment]
           this.dialogCreateSegmentOpen = false
@@ -432,10 +445,11 @@ export default {
     // --- Distributions ---
     handleEditDistribution(segment) {
       this.selectedSegment = segment
-      this.distributionDraft = {}
-      segment.distributions.forEach(d => {
-        this.distributionDraft[d.variantID] = clone(d)
-      })
+      const draft = {}
+      for (const d of segment.distributions) {
+        draft[d.variantID] = { ...d }
+      }
+      this.distributionDraft = draft
       this.dialogEditDistributionOpen = true
     },
 
@@ -468,9 +482,7 @@ export default {
     // --- Data fetching ---
     fetchFlag() {
       Axios.get(`${API_URL}/flags/${this.flagId}`).then(response => {
-        const flag = response.data
-        flag.variants.forEach(v => processVariant(v))
-        this.flag = flag
+        this.flag = normalizeFlag(response.data)
         this.loaded = true
       }, handleErr.bind(this))
       this.fetchEntityTypes()

--- a/browser/flagr-ui/src/components/SegmentsSection.vue
+++ b/browser/flagr-ui/src/components/SegmentsSection.vue
@@ -85,9 +85,9 @@
             </div>
           </div>
           <div class="seg-panel seg-panel-dist">
-            <div class="seg-section-title">
+            <div class="seg-section-title seg-section-title--with-action">
               <span>Distribution</span>
-              <el-button size="small" link type="primary" @click="$emit('edit-distribution', element)"><el-icon><Edit /></el-icon> Edit</el-button>
+              <el-button size="small" link type="primary" data-testid="edit-distribution-btn" @click="$emit('edit-distribution', element)"><el-icon><Edit /></el-icon> Edit</el-button>
             </div>
             <div v-if="element.distributions.length" class="dist-list">
               <div v-for="distribution in element.distributions" :key="distribution.id" class="dist-item">
@@ -141,7 +141,7 @@ export default {
       const c = this.newConstraints[element.id]
       this.$emit('create-constraint', { segment: element, constraint: { operator: c.operator, property: c.property, value: c.value } })
       this.newConstraints[element.id] = { operator: 'EQ', property: '', value: '' }
-    }
+    },
   }
 }
 </script>
@@ -216,6 +216,13 @@ export default {
   gap: var(--space-2xs);
   letter-spacing: 0.02em;
   text-transform: uppercase;
+}
+.seg-section-title--with-action {
+  justify-content: space-between;
+  :deep(.el-button) {
+    text-transform: none;
+    letter-spacing: normal;
+  }
 }
 .seg-section-subtitle {
   font-weight: 400;


### PR DESCRIPTION
## Description

Fixes the **Distribution → Edit** control on the flag detail page so the edit modal opens reliably.

- **`clone(d)`** was still referenced in `handleEditDistribution` after the Vue 3 migration removed `lodash.clone`, causing a `ReferenceError` whenever a segment had existing distributions (the draft loop ran).
- Removing a defensive leading `;` briefly reintroduced an **ASI** hazard (`{}` followed by `(…).forEach`); draft building now uses a **`for…of`** loop and shallow `{ ...d }` copies.
- **`normalizeSegment` / `normalizeFlag`** ensure every segment has `constraints` and `distributions` arrays at fetch and on create (single canonical place, no scattered `|| []`).
- **UI:** Distribution **Edit** stays a link button, right-aligned via `seg-section-title--with-action`; `data-testid="edit-distribution-btn"` for stable e2e.
- **E2e:** `getFlag` / `putSegmentDistributions` helpers; distribution test seeds a 100% distribution before Edit and asserts the dialog and checked variant (covers the path that used to hit `clone`).

## Motivation and Context

Users could not open the distribution editor when segments already had distributions; the handler threw before `dialogEditDistributionOpen` was set.

## How Has This Been Tested?

- `cd browser/flagr-ui && npm run lint`
- `npm run test:e2e -- e2e/flag-detail.spec.js` (22 tests)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.