### PR TITLE
chore(docs): pin Docsify 4.13.1 and align vue.css typography

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,7 @@ stop-ui:
 rebuild-run: build stop-ui start
 
 serve-docs:
-	@npm install -g docsify-cli@4
+	@npm install -g docsify-cli@4.4.4
 	@docsify serve $(PWD)/docs
 
 # ------------------------------------------------------------------------------

--- a/docs/index.html
+++ b/docs/index.html
@@ -7,35 +7,30 @@
     <meta name="description" content="Flagr — open source feature flagging, A/B testing, and dynamic configuration in Go." />
     <meta
       name="viewport"
-      content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0"
+      content="width=device-width, initial-scale=1.0, minimum-scale=1.0"
     />
     <link rel="icon" href="images/favicon.png" />
-    <link rel="stylesheet" href="//unpkg.com/docsify/lib/themes/vue.css" />
+    <link
+      rel="stylesheet"
+      href="//cdn.jsdelivr.net/npm/docsify@4.13.1/lib/themes/vue.css"
+    />
     <style>
       :root {
         --theme-color: #2e4960;
       }
 
-      code {
-        font-size: 15px !important;
-      }
-      p {
-        line-height: 1.2rem !important;
-      }
-      p code {
-        padding: 0px !important;
-      }
       img {
         margin-top: 1rem;
       }
     </style>
   </head>
   <body>
-    <script src="//unpkg.com/docsify-edit-on-github@1.0.1/index.js"></script>
+    <div id="app">Loading …</div>
+    <script src="//cdn.jsdelivr.net/npm/docsify-edit-on-github@1.0.1/index.js"></script>
 
-    <div id="app"></div>
     <script>
       window.$docsify = {
+        auto2top: true,
         loadSidebar: true,
         maxLevel: 4,
         subMaxLevel: 2,
@@ -61,11 +56,11 @@
       };
     </script>
 
-    <script src="//unpkg.com/mermaid@10/dist/mermaid.min.js"></script>
-    <script src="//unpkg.com/docsify/lib/docsify.min.js"></script>
-    <script src="//unpkg.com/docsify-mermaid@2/dist/docsify-mermaid.js"></script>
-    <script src="//unpkg.com/docsify/lib/plugins/search.min.js"></script>
-    <script src="//unpkg.com/prismjs/components/prism-bash.min.js"></script>
-    <script src="//unpkg.com/prismjs/components/prism-go.min.js"></script>
+    <script src="//cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.min.js"></script>
+    <script src="//cdn.jsdelivr.net/npm/docsify@4.13.1/lib/docsify.min.js"></script>
+    <script src="//cdn.jsdelivr.net/npm/docsify-mermaid@2.0.1/dist/docsify-mermaid.js"></script>
+    <script src="//cdn.jsdelivr.net/npm/docsify@4.13.1/lib/plugins/search.min.js"></script>
+    <script src="//cdn.jsdelivr.net/npm/prismjs@1/components/prism-bash.min.js"></script>
+    <script src="//cdn.jsdelivr.net/npm/prismjs@1/components/prism-go.min.js"></script>
   </body>
 </html>


### PR DESCRIPTION
## Description

Updates the Flagr documentation site (`docs/index.html`) to use the latest published [Docsify](https://github.com/docsifyjs/docsify) release (**4.13.1**) via jsDelivr, and removes local CSS overrides that made typography diverge from the official `vue.css` theme.

Changes:
- Pin CDN assets: `docsify@4.13.1`, `docsify-mermaid@2.0.1`, `mermaid@10`, `prismjs@1`
- Switch from unpinned `unpkg.com` to versioned `cdn.jsdelivr.net` URLs (matches upstream docs guidance)
- Enable `auto2top`, update viewport meta, and show a loading placeholder in `#app`
- Remove `!important` rules on `code`, `p`, and `p code` so body/code match `vue.css` (Source Sans Pro / Roboto Mono sizing and 1.6rem line height)
- Keep Flagr branding via `--theme-color: #2e4960` and image spacing
- Pin `docsify-cli@4.4.4` in `make serve-docs`

## Motivation and Context

Docs were loading unpinned Docsify from unpkg and custom typography overrides produced a denser, heavier look than the official Docsify `vue.css` site. Pinning versions improves reproducibility; dropping the overrides aligns local preview with [docsify.js.org](https://docsify.js.org).

## How Has This Been Tested?

- `npx docsify-cli@4.4.4 serve docs -p 3999` — HTTP 200 for `index.html`
- Visual check: paragraph line-height and inline code size should match default `vue.css` after hard refresh

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.