### PR TITLE
Prepare 1.2.1 release

### DIFF
--- a/browser/flagr-ui/package-lock.json
+++ b/browser/flagr-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "flagr-ui",
-    "version": "1.2.0",
+    "version": "1.2.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "flagr-ui",
-            "version": "1.2.0",
+            "version": "1.2.1",
             "dependencies": {
                 "@element-plus/icons-vue": "^2.3.1",
                 "@vscode/markdown-it-katex": "^1.1.2",

--- a/browser/flagr-ui/package.json
+++ b/browser/flagr-ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "flagr-ui",
-    "version": "1.2.0",
+    "version": "1.2.1",
     "private": true,
     "scripts": {
         "dev": "vite",

--- a/docs/api_docs/bundle.yaml
+++ b/docs/api_docs/bundle.yaml
@@ -4,7 +4,7 @@ info:
     Flagr is a feature flagging, A/B testing and dynamic configuration
     microservice. The base path for all the APIs is "/api/v1".
   title: Flagr
-  version: 1.2.0
+  version: 1.2.1
 tags:
   - name: flag
     description: Everything about the flag

--- a/swagger/index.yaml
+++ b/swagger/index.yaml
@@ -5,7 +5,7 @@ info:
     Flagr is a feature flagging, A/B testing and dynamic configuration microservice.
     The base path for all the APIs is "/api/v1".
   title: Flagr
-  version: 1.2.0
+  version: 1.2.1
 tags:
   - name: flag
     description: Everything about the flag

--- a/swagger_gen/restapi/doc.go
+++ b/swagger_gen/restapi/doc.go
@@ -8,7 +8,7 @@
 //	  http
 //	Host: localhost
 //	BasePath: /api/v1
-//	Version: 1.2.0
+//	Version: 1.2.1
 //
 //	Consumes:
 //	  - application/json

--- a/swagger_gen/restapi/embedded_spec.go
+++ b/swagger_gen/restapi/embedded_spec.go
@@ -28,7 +28,7 @@ func init() {
   "info": {
     "description": "Flagr is a feature flagging, A/B testing and dynamic configuration microservice. The base path for all the APIs is \"/api/v1\".\n",
     "title": "Flagr",
-    "version": "1.2.0"
+    "version": "1.2.1"
   },
   "basePath": "/api/v1",
   "paths": {
@@ -2511,7 +2511,7 @@ func init() {
   "info": {
     "description": "Flagr is a feature flagging, A/B testing and dynamic configuration microservice. The base path for all the APIs is \"/api/v1\".\n",
     "title": "Flagr",
-    "version": "1.2.0"
+    "version": "1.2.1"
   },
   "basePath": "/api/v1",
   "paths": {


### PR DESCRIPTION
Bumps project version from 1.2.0 to 1.2.1 (same touchpoints as #718).

**Included since 1.2.0:**
- #719 perf: faster flag evaluation on hot path
- #720 fix(ui): restore distribution Edit dialog
- #721 feat(ui): TypeScript + ApiResult REST layer
- #722 chore(docs): pin Docsify 4.13.1

**After merge:** tag `1.2.1` on `main` and publish the GitHub release (`.github/workflows/cd_docker.yml` runs on `release: published`).