### PR TITLE
fix(eval): return segmentID=0 when no segment matches

### DIFF
--- a/pkg/handler/eval.go
+++ b/pkg/handler/eval.go
@@ -232,10 +232,10 @@ var EvalFlagWithContext = func(flag *entity.Flag, evalContext models.EvalContext
 		logs = make([]*models.SegmentDebugLog, 0, len(flag.Segments))
 	}
 	for _, segment := range flag.Segments {
-		sID = int64(segment.ID)
 		variantID, log, evalNextSegment := evalSegment(evalContext, segment)
 		if variantID != nil {
 			vID = int64(*variantID)
+			sID = int64(segment.ID)
 		}
 		if config.Config.EvalDebugEnabled && evalContext.EnableDebug {
 			logs = append(logs, log)

--- a/pkg/handler/eval_test.go
+++ b/pkg/handler/eval_test.go
@@ -486,6 +486,45 @@ func TestEvalFlag(t *testing.T) {
 		assert.Zero(t, result.VariantID)
 	})
 
+	t.Run("segmentID is zero when no segment matches", func(t *testing.T) {
+		f := entity.GenFixtureFlag()
+		// Segment has constraint dl_state == "CA"
+		f.PrepareEvaluation()
+		ec := &EvalCache{
+			cache: &cacheContainer{idCache: map[string]*entity.Flag{"100": &f}},
+		}
+		defer gostub.StubFunc(&GetEvalCache, ec).Reset()
+		result := EvalFlag(models.EvalContext{
+			EnableDebug:   true,
+			EntityContext: map[string]any{"dl_state": "NY"},
+			EntityID:      "entityID1",
+			EntityType:    "entityType1",
+			FlagID:        int64(100),
+		})
+		assert.NotNil(t, result)
+		assert.Zero(t, result.VariantID)
+		assert.Zero(t, result.SegmentID, "segmentID should be 0 when no segment matches")
+	})
+
+	t.Run("segmentID is set when a segment matches", func(t *testing.T) {
+		f := entity.GenFixtureFlag()
+		f.PrepareEvaluation()
+		ec := &EvalCache{
+			cache: &cacheContainer{idCache: map[string]*entity.Flag{"100": &f}},
+		}
+		defer gostub.StubFunc(&GetEvalCache, ec).Reset()
+		result := EvalFlag(models.EvalContext{
+			EnableDebug:   true,
+			EntityContext: map[string]any{"dl_state": "CA"},
+			EntityID:      "entityID1",
+			EntityType:    "entityType1",
+			FlagID:        int64(100),
+		})
+		assert.NotNil(t, result)
+		assert.NotZero(t, result.VariantID)
+		assert.Equal(t, int64(200), result.SegmentID, "segmentID should be the matched segment's ID")
+	})
+
 	t.Run("test enabled=false", func(t *testing.T) {
 		f := entity.GenFixtureFlag()
 		f.Enabled = false


### PR DESCRIPTION
## Summary

Fix incorrect `segmentID` in evaluation results when no segment matches.

Closes #440

## Problem

In `EvalFlagWithContext`, `sID = int64(segment.ID)` was set at the top of the segment loop **before** checking if the segment matched. When no segment matched, `sID` held the **last** segment's ID, which is incorrect.

## Fix

Move `sID` assignment inside the `variantID != nil` check so it's only set when a segment actually matches. When no segment matches, `segmentID` is now `0`.

## Tests

Added two test cases:
- `segmentID is zero when no segment matches` — entityContext `{dl_state: "NY"}` against segment requiring `dl_state == "CA"`
- `segmentID is set when a segment matches` — entityContext `{dl_state: "CA"}` correctly returns segmentID 200

## Impact

Consumers that rely on `segmentID` being non-zero when the flag is enabled will now see `0` when no segment matches. This is more accurate — no downstream logic depends on `segmentID` being non-zero (exposure logging hardcodes it to 0, data recording is informational only).
