### PR TITLE
feat(config): add FLAGR_UI_ENABLED to disable the UI

### DIFF
--- a/pkg/config/env.go
+++ b/pkg/config/env.go
@@ -42,6 +42,9 @@ var Config = struct {
 	// EvalOnlyMode - will only expose the evaluation related endpoints.
 	// This field will be derived from DBDriver
 	EvalOnlyMode bool `env:"FLAGR_EVAL_ONLY_MODE" envDefault:"false"`
+	// UIEnabled controls whether the Flagr UI is served.
+	// Set to false for backend-only deployments where the UI is not needed.
+	UIEnabled bool `env:"FLAGR_UI_ENABLED" envDefault:"true"`
 
 	// EvalBatchSize - maximum number of total evaluations allowed in a single batch request.
 	// This is calculated as: len(entities) * (len(flagIDs) + len(flagKeys) + estimated_flags_from_tags).

--- a/pkg/config/middleware.go
+++ b/pkg/config/middleware.go
@@ -91,11 +91,13 @@ func SetupGlobalMiddleware(handler http.Handler) http.Handler {
 		n.Use(setupBasicAuthMiddleware())
 	}
 
-	n.Use(&negroni.Static{
-		Dir:       http.Dir("./browser/flagr-ui/dist/"),
-		Prefix:    Config.WebPrefix,
-		IndexFile: "index.html",
-	})
+	if Config.UIEnabled {
+		n.Use(&negroni.Static{
+			Dir:       http.Dir("./browser/flagr-ui/dist/"),
+			Prefix:    Config.WebPrefix,
+			IndexFile: "index.html",
+		})
+	}
 
 	n.Use(setupRecoveryMiddleware())
 


### PR DESCRIPTION
## Summary

Add `FLAGR_UI_ENABLED` environment variable to disable serving the Flagr UI.

Closes #533

## Problem

Some deployments need to run Flagr as a backend-only service without the UI for security or architecture reasons (e.g., company policy prevents backend services from coexisting with UI, or teams build custom UIs).

## Fix

- Add `FLAGR_UI_ENABLED` env var (default: `true`) to `pkg/config/env.go`
- Wrap the `negroni.Static` middleware registration in a conditional in `pkg/config/middleware.go`

When `FLAGR_UI_ENABLED=false`, the static file server for the UI is not registered, so the UI is not served. All API endpoints remain functional.

## Usage

```bash
FLAGR_UI_ENABLED=false ./flagr
```