### PR TITLE
feat(ui): add colour coded tags in Flagr UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ coverage.txt
 progress.md
 integration-bench.txt
 
+node_modules/

--- a/browser/flagr-ui/src/components/FlagConfigCard.vue
+++ b/browser/flagr-ui/src/components/FlagConfigCard.vue
@@ -124,7 +124,8 @@
               :key="tag.id"
               closable
               size="small"
-              type="success"
+              effect="plain"
+              :style="{ backgroundColor: tagColor(tag.value), borderColor: 'transparent' }"
               @close="$emit('delete-tag', tag)"
             >
               {{ tag.value }}
@@ -196,6 +197,7 @@ import {
 } from '@/helpers/saveDirtyUi'
 import { defineAsyncComponent, type PropType } from 'vue'
 import { InfoFilled, Edit, View } from '@element-plus/icons-vue'
+import { tagColor } from '@/helpers/tagColor'
 import type { FlagView, Tag } from '@/api/types'
 
 interface EntityTypeOption {
@@ -237,6 +239,7 @@ export default {
     }
   },
   methods: {
+    tagColor,
     saveButtonLabel(dirty: boolean) {
       return fmtSaveLabel(dirty)
     },

--- a/browser/flagr-ui/src/components/Flags.vue
+++ b/browser/flagr-ui/src/components/Flags.vue
@@ -78,9 +78,9 @@
                 <el-tag
                   v-for="tag in scope.row.tags"
                   :key="tag.id"
-                  type="success"
                   size="small"
-                  effect="light"
+                  effect="plain"
+                  :style="{ backgroundColor: tagColor(tag.value), borderColor: 'transparent' }"
                 >
                   {{ tag.value }}
                 </el-tag>
@@ -185,9 +185,9 @@
                     <el-tag
                       v-for="tag in scope.row.tags"
                       :key="tag.id"
-                      type="success"
                       size="small"
-                      effect="light"
+                      effect="plain"
+                      :style="{ backgroundColor: tagColor(tag.value), borderColor: 'transparent' }"
                     >
                       {{ tag.value }}
                     </el-tag>
@@ -299,6 +299,7 @@ import { Plus, Search } from '@element-plus/icons-vue'
 import Spinner from '@/components/Spinner.vue'
 import { getFlagsCache } from '@/pages/flagsListPage'
 import helpers from '@/helpers/helpers'
+import { tagColor } from '@/helpers/tagColor'
 import { castFlagsList } from '@/helpers/vuePageCast'
 import * as flagsListPage from '@/pages/flagsListPage'
 import {
@@ -384,6 +385,7 @@ export default {
     goToRow(row: Flag) {
       flagsListPage.goToFlag(this.page, row)
     },
+    tagColor,
     datetimeFormatter,
     filterStatus,
   },

--- a/browser/flagr-ui/src/helpers/tagColor.test.ts
+++ b/browser/flagr-ui/src/helpers/tagColor.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+import { tagColor } from './tagColor'
+
+describe('tagColor', () => {
+  it('returns same colour for same input', () => {
+    expect(tagColor('team:payments')).toBe(tagColor('team:payments'))
+  })
+
+  it('returns different colours for different inputs', () => {
+    expect(tagColor('team:payments')).not.toBe(tagColor('team:auth'))
+  })
+
+  it('returns valid HSL string', () => {
+    const color = tagColor('test')
+    expect(color).toMatch(/^hsl\(\d+, 55%, 92%\)$/)
+  })
+
+  it('handles empty string', () => {
+    expect(tagColor('')).toBe('hsl(0, 55%, 92%)')
+  })
+})

--- a/browser/flagr-ui/src/helpers/tagColor.ts
+++ b/browser/flagr-ui/src/helpers/tagColor.ts
@@ -1,0 +1,12 @@
+/**
+ * Deterministic colour for a tag value.  Hashes the string to a hue (0-360)
+ * and returns an HSL background colour suitable for el-tag :style.
+ */
+export function tagColor(value: string): string {
+  let h = 0
+  for (let i = 0; i < value.length; i++) {
+    h = value.charCodeAt(i) + ((h << 5) - h)
+  }
+  const hue = ((h % 360) + 360) % 360
+  return `hsl(${hue}, 55%, 92%)`
+}


### PR DESCRIPTION
## Description

Tags now render with deterministic colours based on a hash of the tag value, making it easier to visually distinguish tags in the flag list and flag detail views.

## Motivation and Context

Closes #438. All tags previously rendered in the same colour, making scanning difficult when many flags share tags.

## How Has This Been Tested?

- `tagColor.test.ts`: 4 tests covering determinism, uniqueness, format, and edge cases
- `npx vitest run`: all 38 tests pass (including new tagColor tests)
- `make flagr-ui-check` passes

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
