### PR TITLE
feat(ui): add Enter key support for creating variants and constraints

### DIFF
--- a/browser/flagr-ui/src/components/ConstraintAddRow.vue
+++ b/browser/flagr-ui/src/components/ConstraintAddRow.vue
@@ -38,6 +38,7 @@
         :model-value="draft.value"
         data-testid="new-constraint-value-input"
         @update:model-value="patch('value', $event)"
+        @keyup.enter="canAdd && $emit('add')"
       />
       <el-button
         size="small"

--- a/browser/flagr-ui/src/components/VariantsSection.vue
+++ b/browser/flagr-ui/src/components/VariantsSection.vue
@@ -92,6 +92,7 @@
         size="small"
         placeholder="New Variant Key"
         data-testid="new-variant-input"
+        @keyup.enter="createVariant"
       />
       <el-button
         type="primary"


### PR DESCRIPTION
## Description

Add Enter key support for creating variants and constraints in the Flagr UI. Pressing Enter in the new variant input or constraint value input now triggers creation, matching the existing behavior for flags and tags.

## Motivation and Context

Closes #306. Currently, pressing Enter in variant and constraint creation inputs does nothing. Users must click the button, which is a UX friction point.

## How Has This Been Tested?

- Verified manually: Enter in new variant input creates the variant
- Verified manually: Enter in constraint value input adds the constraint
- `make flagr-ui-check` passes (lint + typecheck + vitest)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
