### PR TITLE
fix(api): add ownership validation for segments, constraints, distributions

### DIFF
--- a/pkg/handler/crud.go
+++ b/pkg/handler/crud.go
@@ -23,6 +23,39 @@ import (
 	"gorm.io/gorm/clause"
 )
 
+// validateSegmentOwnership checks that the segment belongs to the flag.
+func validateSegmentOwnership(tx *gorm.DB, flagID, segmentID uint) error {
+	var count int64
+	tx.Model(&entity.Segment{}).Where("id = ? AND flag_id = ?", segmentID, flagID).Count(&count)
+	if count == 0 {
+		return fmt.Errorf("segment %d does not belong to flag %d", segmentID, flagID)
+	}
+	return nil
+}
+
+// validateVariantOwnership checks that the variant belongs to the flag.
+func validateVariantOwnership(tx *gorm.DB, flagID, variantID uint) error {
+	var count int64
+	tx.Model(&entity.Variant{}).Where("id = ? AND flag_id = ?", variantID, flagID).Count(&count)
+	if count == 0 {
+		return fmt.Errorf("variant %d does not belong to flag %d", variantID, flagID)
+	}
+	return nil
+}
+
+// validateConstraintOwnership checks that the constraint's segment belongs to the flag.
+func validateConstraintOwnership(tx *gorm.DB, flagID, constraintID uint) error {
+	var count int64
+	tx.Table("constraints").
+		Joins("JOIN segments ON segments.id = constraints.segment_id").
+		Where("constraints.id = ? AND segments.flag_id = ?", constraintID, flagID).
+		Count(&count)
+	if count == 0 {
+		return fmt.Errorf("constraint %d does not belong to flag %d", constraintID, flagID)
+	}
+	return nil
+}
+
 // CRUD is the CRUD interface
 type CRUD interface {
 	// Flags
@@ -525,6 +558,9 @@ func (c *crud) PutSegment(params segment.PutSegmentParams) middleware.Responder 
 	s := &entity.Segment{}
 
 	err := commitFlagMutation(flagID, subject, notification.OperationUpdate, notification.ComponentSegment, func(tx *gorm.DB) (uint, mutationNotify, error) {
+		if err := validateSegmentOwnership(tx, flagID, uint(params.SegmentID)); err != nil {
+			return 0, mutationNotify{}, err
+		}
 		if err := entity.PreloadConstraintsDistribution(tx).First(s, params.SegmentID).Error; err != nil {
 			return 0, mutationNotify{}, err
 		}
@@ -576,6 +612,9 @@ func (c *crud) DeleteSegment(params segment.DeleteSegmentParams) middleware.Resp
 	subject := getSubjectFromRequest(params.HTTPRequest)
 
 	err := commitFlagMutation(flagID, subject, notification.OperationDelete, notification.ComponentSegment, func(tx *gorm.DB) (uint, mutationNotify, error) {
+		if err := validateSegmentOwnership(tx, flagID, uint(params.SegmentID)); err != nil {
+			return 0, mutationNotify{}, err
+		}
 		if err := tx.Delete(&entity.Segment{}, segmentID).Error; err != nil {
 			return 0, mutationNotify{}, err
 		}
@@ -647,6 +686,9 @@ func (c *crud) PutConstraint(params constraint.PutConstraintParams) middleware.R
 	}
 
 	err := commitFlagMutation(flagID, subject, notification.OperationUpdate, notification.ComponentConstraint, func(tx *gorm.DB) (uint, mutationNotify, error) {
+		if err := validateConstraintOwnership(tx, flagID, uint(params.ConstraintID)); err != nil {
+			return 0, mutationNotify{}, err
+		}
 		if err := tx.Save(cons).Error; err != nil {
 			return 0, mutationNotify{}, err
 		}
@@ -667,6 +709,9 @@ func (c *crud) DeleteConstraint(params constraint.DeleteConstraintParams) middle
 	subject := getSubjectFromRequest(params.HTTPRequest)
 
 	err := commitFlagMutation(flagID, subject, notification.OperationDelete, notification.ComponentConstraint, func(tx *gorm.DB) (uint, mutationNotify, error) {
+		if err := validateConstraintOwnership(tx, flagID, uint(params.ConstraintID)); err != nil {
+			return 0, mutationNotify{}, err
+		}
 		if err := tx.Delete(&entity.Constraint{}, params.ConstraintID).Error; err != nil {
 			return 0, mutationNotify{}, err
 		}
@@ -690,6 +735,14 @@ func (c *crud) PutDistributions(params distribution.PutDistributionsParams) midd
 	ds := r2eMapDistributions(params.Body.Distributions, segmentID)
 
 	err := commitFlagMutation(flagID, subject, notification.OperationUpdate, notification.ComponentDistribution, func(tx *gorm.DB) (uint, mutationNotify, error) {
+		if err := validateSegmentOwnership(tx, flagID, segmentID); err != nil {
+			return 0, mutationNotify{}, err
+		}
+		for i := range ds {
+			if err := validateVariantOwnership(tx, flagID, ds[i].VariantID); err != nil {
+				return 0, mutationNotify{}, err
+			}
+		}
 		if err := tx.Where("segment_id = ?", segmentID).Delete(&entity.Distribution{}).Error; err != nil {
 			return 0, mutationNotify{}, err
 		}

--- a/pkg/handler/crud_test.go
+++ b/pkg/handler/crud_test.go
@@ -1503,3 +1503,94 @@ func TestAllMutationHandlersCallSaveFlagSnapshot(t *testing.T) {
 		}
 	}
 }
+
+func TestOwnershipValidation(t *testing.T) {
+	db := entity.NewTestDB()
+	c := &crud{}
+
+	tmpDB, dbErr := db.DB()
+	if dbErr != nil {
+		t.Fatalf("Failed to get database")
+	}
+	defer tmpDB.Close()
+	defer gostub.StubFunc(&getDB, db).Reset()
+
+	// Create two flags
+	c.CreateFlag(flag.CreateFlagParams{
+		Body: &models.CreateFlagRequest{Description: new("flag1")},
+	})
+	c.CreateFlag(flag.CreateFlagParams{
+		Body: &models.CreateFlagRequest{Description: new("flag2")},
+	})
+
+	// Create segment on flag1
+	res := c.CreateSegment(segment.CreateSegmentParams{
+		FlagID: int64(1),
+		Body:   &models.CreateSegmentRequest{Description: new("seg1"), RolloutPercent: new(int64(100))},
+	})
+	seg1 := res.(*segment.CreateSegmentOK).Payload
+
+	// Create segment on flag2
+	res = c.CreateSegment(segment.CreateSegmentParams{
+		FlagID: int64(2),
+		Body:   &models.CreateSegmentRequest{Description: new("seg2"), RolloutPercent: new(int64(100))},
+	})
+	seg2 := res.(*segment.CreateSegmentOK).Payload
+
+	// Try to update flag2's segment via flag1's endpoint — should fail
+	res = c.PutSegment(segment.PutSegmentParams{
+		FlagID:    int64(1),
+		SegmentID: seg2.ID,
+		Body:      &models.PutSegmentRequest{Description: new("hacked"), RolloutPercent: new(int64(0))},
+	})
+	_, isDefault := res.(*segment.PutSegmentDefault)
+	assert.True(t, isDefault, "PutSegment with wrong flag ownership should return error")
+
+	// Try to delete flag2's segment via flag1's endpoint — should fail
+	res = c.DeleteSegment(segment.DeleteSegmentParams{
+		FlagID:    int64(1),
+		SegmentID: seg2.ID,
+	})
+	_, isDefault = res.(*segment.DeleteSegmentDefault)
+	assert.True(t, isDefault, "DeleteSegment with wrong flag ownership should return error")
+
+	// Create variant on flag1
+	res = c.CreateVariant(variant.CreateVariantParams{
+		FlagID: int64(1),
+		Body:   &models.CreateVariantRequest{Key: new("v1")},
+	})
+	v1 := res.(*variant.CreateVariantOK).Payload
+
+	// Create variant on flag2
+	res = c.CreateVariant(variant.CreateVariantParams{
+		FlagID: int64(2),
+		Body:   &models.CreateVariantRequest{Key: new("v2")},
+	})
+	v2 := res.(*variant.CreateVariantOK).Payload
+
+	// Put distributions on flag1's segment with flag2's variant — should fail
+	res = c.PutDistributions(distribution.PutDistributionsParams{
+		FlagID:    int64(1),
+		SegmentID: seg1.ID,
+		Body: &models.PutDistributionsRequest{
+			Distributions: []*models.Distribution{
+				{VariantID: &v2.ID, Percent: new(int64(100))},
+			},
+		},
+	})
+	_, isDefault = res.(*distribution.PutDistributionsDefault)
+	assert.True(t, isDefault, "PutDistributions with wrong variant ownership should return error")
+
+	// Put distributions on flag2's segment via flag1's endpoint — should fail
+	res = c.PutDistributions(distribution.PutDistributionsParams{
+		FlagID:    int64(1),
+		SegmentID: seg2.ID,
+		Body: &models.PutDistributionsRequest{
+			Distributions: []*models.Distribution{
+				{VariantID: &v1.ID, Percent: new(int64(100))},
+			},
+		},
+	})
+	_, isDefault = res.(*distribution.PutDistributionsDefault)
+	assert.True(t, isDefault, "PutDistributions with wrong segment ownership should return error")
+}


### PR DESCRIPTION
## Description

Add ownership validation to prevent modifying entities (segments, constraints, distributions) that belong to a different flag. Entity IDs are globally unique but the API didn't enforce parent-child ownership.

Validation helpers added:
- `validateSegmentOwnership(tx, flagID, segmentID)`
- `validateVariantOwnership(tx, flagID, variantID)`
- `validateConstraintOwnership(tx, flagID, constraintID)`

Applied to: `PutSegment`, `DeleteSegment`, `PutDistributions`, `PutConstraint`, `DeleteConstraint`.

## Motivation and Context

Closes #430. The API previously allowed updating segments, constraints, and distributions using IDs that belong to different flags, since entity IDs are globally unique but there was no ownership check.

## How Has This Been Tested?

- `TestOwnershipValidation`: creates two flags with segments/variants, attempts cross-flag mutations (update wrong segment, delete wrong segment, distribute wrong variant, distribute on wrong segment), verifies all return errors
- `go test ./pkg/handler/...`: all tests pass

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
