### PR TITLE
ci: revert direct pushes to main, add branch rule to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,3 +67,4 @@ Run from **repo root**. Match what [`.github/workflows/ci.yml`](.github/workflow
 - See [deepwiki.com/openflagr/flagr](https://deepwiki.com/openflagr/flagr) and `docs/`
 - **File size & layout:** Prefer **medium-sized** files with a clear, logical split — not monoliths, not one-off micro-files for a single helper. Group by responsibility (e.g. handler `error.go` for API/handler errors and DB error classification; `validate.go` for request validation; `crud*.go` for CRUD surfaces). New code should extend an existing cohesive file when it fits; add a new file only when it names a real subsystem or API slice.
 - When creating a PR, follow `PULL_REQUEST_TEMPLATE.md`
+- **Never push directly to `main`** — all changes must go through a PR with CI passing first.

--- a/integration_tests/integration_test.go
+++ b/integration_tests/integration_test.go
@@ -578,12 +578,11 @@ func TestIntegration_EvalCacheExportQuery(t *testing.T) {
 	postJSON(t, fmt.Sprintf("/api/v1/flags/%d/tags", enabledFlag.ID), map[string]any{"value": tagVal2}, nil)
 	postJSON(t, fmt.Sprintf("/api/v1/flags/%d/tags", disabledFlag.ID), map[string]any{"value": tagVal2}, nil)
 
-	// Wait for eval cache to pick up the new flags by polling for the enabled flag by ID.
-	// Can't just check len >= 2 because seeded flags already satisfy that.
+	// Wait for eval cache to contain the new flags (poll instead of fixed sleep)
 	err := pollUntil("eval cache export", "/api/v1/export/eval_cache/json", 10*time.Second, func() bool {
 		var cache struct{ Flags []flagResponse }
-		getJSON(t, fmt.Sprintf("/api/v1/export/eval_cache/json?ids=%d", enabledFlag.ID), &cache)
-		return len(cache.Flags) == 1
+		getJSON(t, "/api/v1/export/eval_cache/json", &cache)
+		return len(cache.Flags) >= 2
 	})
 	if err != nil {
 		t.Fatalf("eval cache did not contain new flags: %v", err)

--- a/integration_tests/integration_test.go
+++ b/integration_tests/integration_test.go
@@ -578,15 +578,8 @@ func TestIntegration_EvalCacheExportQuery(t *testing.T) {
 	postJSON(t, fmt.Sprintf("/api/v1/flags/%d/tags", enabledFlag.ID), map[string]any{"value": tagVal2}, nil)
 	postJSON(t, fmt.Sprintf("/api/v1/flags/%d/tags", disabledFlag.ID), map[string]any{"value": tagVal2}, nil)
 
-	// Wait for eval cache to contain the new flags (poll instead of fixed sleep)
-	err := pollUntil("eval cache export", "/api/v1/export/eval_cache/json", 10*time.Second, func() bool {
-		var cache struct{ Flags []flagResponse }
-		getJSON(t, "/api/v1/export/eval_cache/json", &cache)
-		return len(cache.Flags) >= 2
-	})
-	if err != nil {
-		t.Fatalf("eval cache did not contain new flags: %v", err)
-	}
+	// Wait for eval cache refresh
+	time.Sleep(2 * time.Second)
 
 	t.Run("no params returns all flags", func(t *testing.T) {
 		var cache struct{ Flags []flagResponse }


### PR DESCRIPTION
## Description

Reverts two commits that were pushed directly to `main`:
- `f8a07b25` fix(ci): poll for specific test flag in export query test
- `771c37ad` fix(ci): deflake TestIntegration_EvalCacheExportQuery by polling instead of fixed sleep

These changes should go through a proper PR. Also adds a "never push directly to main" rule to AGENTS.md.

## Motivation

All changes must go through a PR with CI passing first. Direct pushes bypass branch protection and risk breaking CI on main.

## Checklist:
- [ ] All new and existing tests passed.
