### PR TITLE
Prepare 1.2.2 release

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,3 +67,4 @@ Run from **repo root**. Match what [`.github/workflows/ci.yml`](.github/workflow
 - See [deepwiki.com/openflagr/flagr](https://deepwiki.com/openflagr/flagr) and `docs/`
 - **File size & layout:** Prefer **medium-sized** files with a clear, logical split — not monoliths, not one-off micro-files for a single helper. Group by responsibility (e.g. handler `error.go` for API/handler errors and DB error classification; `validate.go` for request validation; `crud*.go` for CRUD surfaces). New code should extend an existing cohesive file when it fits; add a new file only when it names a real subsystem or API slice.
 - When creating a PR, follow `PULL_REQUEST_TEMPLATE.md`
+- **Never push directly to `main`** — always create a PR

--- a/browser/flagr-ui/package-lock.json
+++ b/browser/flagr-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "flagr-ui",
-    "version": "1.2.1",
+    "version": "1.2.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "flagr-ui",
-            "version": "1.2.1",
+            "version": "1.2.2",
             "dependencies": {
                 "@element-plus/icons-vue": "^2.3.1",
                 "@vscode/markdown-it-katex": "^1.1.2",

--- a/browser/flagr-ui/package.json
+++ b/browser/flagr-ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "flagr-ui",
-    "version": "1.2.1",
+    "version": "1.2.2",
     "private": true,
     "scripts": {
         "dev": "vite",

--- a/docs/api_docs/bundle.yaml
+++ b/docs/api_docs/bundle.yaml
@@ -4,7 +4,7 @@ info:
     Flagr is a feature flagging, A/B testing and dynamic configuration
     microservice. The base path for all the APIs is "/api/v1".
   title: Flagr
-  version: 1.2.1
+  version: 1.2.2
 tags:
   - name: flag
     description: Everything about the flag

--- a/swagger/index.yaml
+++ b/swagger/index.yaml
@@ -5,7 +5,7 @@ info:
     Flagr is a feature flagging, A/B testing and dynamic configuration microservice.
     The base path for all the APIs is "/api/v1".
   title: Flagr
-  version: 1.2.1
+  version: 1.2.2
 tags:
   - name: flag
     description: Everything about the flag

--- a/swagger_gen/restapi/doc.go
+++ b/swagger_gen/restapi/doc.go
@@ -8,7 +8,7 @@
 //	  http
 //	Host: localhost
 //	BasePath: /api/v1
-//	Version: 1.2.1
+//	Version: 1.2.2
 //
 //	Consumes:
 //	  - application/json

--- a/swagger_gen/restapi/embedded_spec.go
+++ b/swagger_gen/restapi/embedded_spec.go
@@ -28,7 +28,7 @@ func init() {
   "info": {
     "description": "Flagr is a feature flagging, A/B testing and dynamic configuration microservice. The base path for all the APIs is \"/api/v1\".\n",
     "title": "Flagr",
-    "version": "1.2.1"
+    "version": "1.2.2"
   },
   "basePath": "/api/v1",
   "paths": {
@@ -2618,7 +2618,7 @@ func init() {
   "info": {
     "description": "Flagr is a feature flagging, A/B testing and dynamic configuration microservice. The base path for all the APIs is \"/api/v1\".\n",
     "title": "Flagr",
-    "version": "1.2.1"
+    "version": "1.2.2"
   },
   "basePath": "/api/v1",
   "paths": {


### PR DESCRIPTION
## Changes since 1.2.1

### Features
- feat: duplicate flag, transactional snapshots, Flag Management UI (#724) (#725)
- feat(flagr-ui): constraint operator UX, sugar-to-EREG, and UI decomposition (#726)
- feat: add query filtering to eval cache export endpoint (#728)
- feat(config): add FLAGR_UI_ENABLED to disable the UI (#730)
- feat(ui): add colour coded tags in Flagr UI (#731)
- feat(ui): add Enter key support for creating variants and constraints (#732)

### Fixes
- fix(flagr-ui): constraint operator hints on dropdown; numeric-only compare copy (#727)
- fix(eval): return segmentID=0 when no segment matches (#729)
- fix(api): add ownership validation for segments, constraints, distributions (#733)
- fix(docs): deploy GitHub Pages via workflow, not legacy Jekyll
- fix(ci): deflake TestIntegration_EvalCacheExportQuery by polling instead of fixed sleep

### Version bump
- `swagger/index.yaml`
- `docs/api_docs/bundle.yaml`
- `swagger_gen/restapi/doc.go`
- `swagger_gen/restapi/embedded_spec.go`
- `browser/flagr-ui/package.json`
- `browser/flagr-ui/package-lock.json`