### PR TITLE
feat(ui): copy flag and history snapshot deep links

### DIFF
--- a/browser/flagr-ui/e2e/flag-detail.spec.ts
+++ b/browser/flagr-ui/e2e/flag-detail.spec.ts
@@ -353,6 +353,42 @@ test.describe('Flag detail page', () => {
     await page.locator('.el-tabs__item').filter({ hasText: 'History' }).click()
     await expect(page.locator('.snapshot-container').first()).toBeVisible({ timeout: 5000 })
   })
+
+  test('copy flag URL and deep-link to a history snapshot', async ({ page, context }) => {
+    await context.grantPermissions(['clipboard-read', 'clipboard-write'])
+    flag = await createFlagWithVariants()
+    const putResp = await page.request.put(`${API}/flags/${flag.id}`, {
+      data: {
+        description: `deeplink-${Date.now()}`,
+        key: flag.key || '',
+        dataRecordsEnabled: false,
+        entityType: '',
+        notes: '',
+      },
+    })
+    expect(putResp.ok()).toBeTruthy()
+    const snaps = await waitForSnapshot(flag.id, { timeout: 5000 })
+    const snapshotId = snaps[0].id
+
+    await page.goto(`/#/flags/${flag.id}`)
+    await expect(page.locator('input[data-testid="flag-key-input"]')).toBeVisible({ timeout: 10000 })
+
+    await page.locator('[data-testid="copy-flag-url-btn"]').click()
+    const flagClip = await page.evaluate(() => navigator.clipboard.readText())
+    expect(flagClip).toContain(`#/flags/${flag.id}`)
+    expect(flagClip).not.toContain('tab=history')
+
+    await page.goto(`/#/flags/${flag.id}?tab=history&snapshot=${snapshotId}`)
+    const snapCard = page.locator(`[data-testid="snapshot-${snapshotId}"]`)
+    await expect(snapCard).toBeVisible({ timeout: 10000 })
+    await expect(snapCard).toHaveClass(/snapshot-container--highlight/)
+
+    await page.locator(`[data-testid="copy-snapshot-url-btn-${snapshotId}"]`).click()
+    const snapClip = await page.evaluate(() => navigator.clipboard.readText())
+    expect(snapClip).toContain(`#/flags/${flag.id}`)
+    expect(snapClip).toContain('tab=history')
+    expect(snapClip).toContain(`snapshot=${snapshotId}`)
+  })
   test('new constraint form clears after creation', async ({ page }) => {
     flag = await createFlag()
     await createSegment(flag.id, `cstr-clear-${Date.now()}`)

--- a/browser/flagr-ui/src/components/CopyLinkButton.vue
+++ b/browser/flagr-ui/src/components/CopyLinkButton.vue
@@ -1,0 +1,136 @@
+<template>
+  <el-tooltip
+    :content="copied ? copiedTooltip : tooltip"
+    placement="top"
+    effect="light"
+    :show-after="tooltipShowAfter"
+    :hide-after="0"
+  >
+    <el-button
+      class="copy-link-btn"
+      :class="{ 'is-copied': copied }"
+      :data-state="copied ? 'copied' : undefined"
+      size="small"
+      link
+      type="primary"
+      :aria-label="copied ? copiedAriaLabel : ariaLabel"
+      :data-testid="testId"
+      :disabled="disabled || !url"
+      @click.stop.prevent="onCopy"
+    >
+      <el-icon>
+        <Check v-if="copied" />
+        <CopyDocument v-else />
+      </el-icon>
+      <span
+        class="copy-link-btn__sr"
+        aria-live="polite"
+      >{{ copied ? 'Copied' : '' }}</span>
+    </el-button>
+  </el-tooltip>
+</template>
+
+<script lang="ts">
+import { Check, CopyDocument } from '@element-plus/icons-vue'
+import { COPY_FEEDBACK_MS, copyText } from '@/helpers/copyText'
+
+const COPY_ERROR_MESSAGE = "Couldn't copy — select and copy manually"
+
+export default {
+  name: 'CopyLinkButton',
+  components: { Check, CopyDocument },
+  props: {
+    /** Absolute URL to copy. */
+    url: { type: String, required: true },
+    /** Accessible name (and tooltip) in the default state. */
+    ariaLabel: { type: String, default: 'Copy link' },
+    tooltip: { type: String, default: 'Copy link' },
+    copiedTooltip: { type: String, default: 'Copied' },
+    copiedAriaLabel: { type: String, default: 'Copied' },
+    testId: { type: String, default: 'copy-link-btn' },
+    disabled: { type: Boolean, default: false },
+    /** Hover tooltip delay (ms). Focus tooltips still open immediately via Element Plus. */
+    tooltipShowAfter: { type: Number, default: 800 },
+  },
+  data() {
+    return {
+      copied: false,
+      revertTimer: 0 as number | ReturnType<typeof setTimeout>,
+    }
+  },
+  beforeUnmount() {
+    this.clearRevertTimer()
+  },
+  methods: {
+    clearRevertTimer() {
+      if (this.revertTimer) {
+        clearTimeout(this.revertTimer)
+        this.revertTimer = 0
+      }
+    },
+    async onCopy() {
+      if (!this.url || this.disabled) return
+      const ok = await copyText(this.url)
+      if (!ok) {
+        this.$message.error(COPY_ERROR_MESSAGE)
+        return
+      }
+      this.copied = true
+      this.clearRevertTimer()
+      this.revertTimer = setTimeout(() => {
+        this.copied = false
+        this.revertTimer = 0
+      }, COPY_FEEDBACK_MS)
+    },
+  },
+}
+</script>
+
+<style lang="scss" scoped>
+/* Hallmark · component: copy-link-button · genre: modern-minimal · theme: inherit-flagr
+ * states: default · hover · focus · active · disabled · loading · error · success
+ * contrast: pass (Element Plus primary + text tokens)
+ */
+.copy-link-btn {
+  vertical-align: middle;
+  padding: var(--space-3xs);
+  min-width: 28px;
+  min-height: 28px;
+  color: var(--el-text-color-secondary);
+
+  &:hover {
+    color: var(--el-color-primary);
+  }
+
+  &:active {
+    transform: translateY(1px);
+  }
+
+  &.is-copied {
+    color: var(--el-color-success);
+  }
+
+  &:disabled {
+    color: var(--el-text-color-placeholder);
+    transform: none;
+  }
+}
+
+.copy-link-btn__sr {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .copy-link-btn:active {
+    transform: none;
+  }
+}
+</style>

--- a/browser/flagr-ui/src/components/Flag.vue
+++ b/browser/flagr-ui/src/components/Flag.vue
@@ -79,8 +79,14 @@
     </el-breadcrumb>
 
     <div v-if="loaded && flag">
-      <el-tabs @tab-click="onHistoryTabClick">
-        <el-tab-pane label="Config">
+      <el-tabs
+        v-model="activeTab"
+        @tab-click="onHistoryTabClick"
+      >
+        <el-tab-pane
+          label="Config"
+          name="config"
+        >
           <flag-config-card
             :flag="flag"
             :show-md-editor="showMdEditor"
@@ -188,6 +194,7 @@
           <flag-history
             v-if="historyLoaded"
             :key="historyKey"
+            :flag-id="flagId"
             :snapshots="flagSnapshots"
           />
         </el-tab-pane>
@@ -206,6 +213,7 @@ import SegmentsSection from '@/components/SegmentsSection.vue'
 import VariantsSection from '@/components/VariantsSection.vue'
 import type { BatchEvalContext, BatchEvalResult, DistributionDraft, EvalContext, EvalResult, EvalSummary, FlagView, Segment, Tag } from '@/api/types'
 import type { EntityTypeOption } from '@/helpers/flagModel'
+import { FLAG_TAB_CONFIG, type FlagTabName } from '@/helpers/shareLinks'
 import { castFlagPage } from '@/helpers/vuePageCast'
 import { handleHistoryTabClick, mountFlagPage } from '@/pages/flagPage'
 import * as flagPage from '@/pages/flagPage'
@@ -264,9 +272,11 @@ export default {
       distributionDraft: {} as Record<string, DistributionDraft>,
       operatorOptions: OPERATOR_UI_OPTIONS,
       showMdEditor: false,
+      activeTab: FLAG_TAB_CONFIG as FlagTabName,
       historyLoaded: false,
       historyKey: 0,
       flagSnapshots: [],
+      pendingSnapshotScrollId: null as number | null,
       evalContext: defaultEvalContext(),
       evalResult: {} as EvalResult,
       evalSummary: null as EvalSummary | null,
@@ -287,8 +297,15 @@ export default {
       handler(id: string | string[] | undefined) {
         this.flagId = String(id ?? '')
         if (this.flagId) {
-          mountFlagPage(this.page)
+          mountFlagPage(this.page, this.$route.query as Record<string, unknown>)
         }
+      },
+    },
+    // Deep-link query changes while already on this flag (e.g. in-app navigation).
+    '$route.query': {
+      handler(query: Record<string, unknown>) {
+        if (!this.loaded || !this.flagId) return
+        flagPage.applyDeepLink(this.page, query)
       },
     },
   },

--- a/browser/flagr-ui/src/components/FlagConfigCard.vue
+++ b/browser/flagr-ui/src/components/FlagConfigCard.vue
@@ -3,9 +3,16 @@
     <template #header>
       <div class="el-card-header">
         <div class="flex-row">
-          <div class="flex-row-left">
+          <div class="flex-row-left flag-config-title">
             <h2>Flag</h2>
             <span class="flag-id ui-id-badge">#{{ flag.id }}</span>
+            <copy-link-button
+              v-if="flag.id != null"
+              :url="flagShareUrl"
+              aria-label="Copy flag URL"
+              tooltip="Copy flag URL"
+              test-id="copy-flag-url-btn"
+            />
           </div>
           <div class="flex-row-right">
             <el-tooltip
@@ -198,6 +205,8 @@ import {
 import { defineAsyncComponent, type PropType } from 'vue'
 import { InfoFilled, Edit, View } from '@element-plus/icons-vue'
 import { tagColor } from '@/helpers/tagColor'
+import { flagUrl } from '@/helpers/shareLinks'
+import CopyLinkButton from '@/components/CopyLinkButton.vue'
 import type { FlagView, Tag } from '@/api/types'
 
 interface EntityTypeOption {
@@ -209,6 +218,7 @@ export default {
   name: 'FlagConfigCard',
   components: {
     MarkdownEditor: defineAsyncComponent(() => import('@/components/MarkdownEditor.vue')),
+    CopyLinkButton,
     InfoFilled,
     Edit,
     View,
@@ -237,6 +247,12 @@ export default {
       newTagValue: '',
       flagDirty: false,
     }
+  },
+  computed: {
+    flagShareUrl(): string {
+      if (this.flag.id == null) return ''
+      return flagUrl(this.flag.id, window.location)
+    },
   },
   methods: {
     tagColor,
@@ -299,6 +315,13 @@ export default {
 
 .flag-notes-panel {
   min-height: 120px;
+}
+
+.flag-config-title {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3xs);
+  min-width: 0;
 }
 
 .flag-id {

--- a/browser/flagr-ui/src/components/FlagHistory.vue
+++ b/browser/flagr-ui/src/components/FlagHistory.vue
@@ -2,8 +2,10 @@
   <div>
     <el-card
       v-for="diff in diffs"
-      :key="diff.timestamp"
+      :id="snapshotElementId(diff.newId)"
+      :key="diff.newId"
       class="snapshot-container"
+      :data-testid="`snapshot-${diff.newId}`"
     >
       <template #header>
         <div class="el-card-header">
@@ -13,6 +15,12 @@
                 <el-tag>Snapshot ID: {{ diff.oldId }}</el-tag>
                 <el-icon><DArrowRight /></el-icon>
                 <el-tag>Snapshot ID: {{ diff.newId }}</el-tag>
+                <copy-link-button
+                  :url="snapshotShareUrl(diff.newId)"
+                  aria-label="Copy link to this change"
+                  tooltip="Copy link to this change"
+                  :test-id="`copy-snapshot-url-btn-${diff.newId}`"
+                />
               </div>
             </div>
             <div class="snapshot-header-right">
@@ -43,14 +51,20 @@
 import xss from 'xss'
 import { diffJson, convertChangesToXML } from 'diff'
 import { DArrowRight } from '@element-plus/icons-vue'
+import CopyLinkButton from '@/components/CopyLinkButton.vue'
+import { flagSnapshotUrl, snapshotElementId } from '@/helpers/shareLinks'
 import type { Flag, FlagHistoryDiffRow, FlagSnapshot } from '@/api/types'
 
 export default {
   name: 'FlagHistory',
-  components: { DArrowRight },
+  components: { DArrowRight, CopyLinkButton },
   props: {
     snapshots: {
       type: Array as () => FlagSnapshot[],
+      required: true,
+    },
+    flagId: {
+      type: [String, Number],
       required: true,
     },
   },
@@ -72,6 +86,10 @@ export default {
     },
   },
   methods: {
+    snapshotElementId,
+    snapshotShareUrl(snapshotId: number) {
+      return flagSnapshotUrl(this.flagId, snapshotId, window.location)
+    },
     getDiff(newFlag: Flag, oldFlag: Flag) {
       const o = JSON.parse(JSON.stringify(oldFlag))
       const n = JSON.parse(JSON.stringify(newFlag))
@@ -96,6 +114,12 @@ export default {
 .snapshot-header-right {
   text-align: right;
   color: var(--el-text-color-secondary);
+}
+.diff-snapshot-id-change {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: var(--space-3xs);
 }
 @media (max-width: 640px) {
   .snapshot-header {

--- a/browser/flagr-ui/src/helpers/copyText.test.ts
+++ b/browser/flagr-ui/src/helpers/copyText.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { COPY_FEEDBACK_MS, SNAPSHOT_HIGHLIGHT_MS, copyText } from './copyText'
+
+describe('copyText', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it('exposes feedback timing constants', () => {
+    expect(COPY_FEEDBACK_MS).toBe(2000)
+    expect(SNAPSHOT_HIGHLIGHT_MS).toBe(1500)
+  })
+
+  it('uses navigator.clipboard.writeText when available', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    vi.stubGlobal('navigator', { clipboard: { writeText } })
+
+    await expect(copyText('https://example.com/#/flags/1')).resolves.toBe(true)
+    expect(writeText).toHaveBeenCalledWith('https://example.com/#/flags/1')
+  })
+
+  it('falls back when clipboard API rejects', async () => {
+    const writeText = vi.fn().mockRejectedValue(new Error('denied'))
+    vi.stubGlobal('navigator', { clipboard: { writeText } })
+
+    const execCommand = vi.fn().mockReturnValue(true)
+    const appendChild = vi.fn()
+    const removeChild = vi.fn()
+    const ta = {
+      value: '',
+      setAttribute: vi.fn(),
+      style: {} as CSSStyleDeclaration,
+      focus: vi.fn(),
+      select: vi.fn(),
+    }
+    vi.stubGlobal('document', {
+      createElement: vi.fn(() => ta),
+      body: { appendChild, removeChild },
+      execCommand,
+    })
+
+    await expect(copyText('hello')).resolves.toBe(true)
+    expect(ta.value).toBe('hello')
+    expect(execCommand).toHaveBeenCalledWith('copy')
+  })
+
+  it('returns false when both paths fail', async () => {
+    vi.stubGlobal('navigator', { clipboard: { writeText: vi.fn().mockRejectedValue(new Error('x')) } })
+    vi.stubGlobal('document', {
+      createElement: vi.fn(() => {
+        throw new Error('no dom')
+      }),
+      body: { appendChild: vi.fn(), removeChild: vi.fn() },
+      execCommand: vi.fn(),
+    })
+
+    await expect(copyText('x')).resolves.toBe(false)
+  })
+})

--- a/browser/flagr-ui/src/helpers/copyText.ts
+++ b/browser/flagr-ui/src/helpers/copyText.ts
@@ -1,0 +1,42 @@
+/** How long the copy control shows the success state before reverting. */
+export const COPY_FEEDBACK_MS = 2000
+
+/** Soft highlight duration when a deep-linked snapshot is scrolled into view. */
+export const SNAPSHOT_HIGHLIGHT_MS = 1500
+
+/**
+ * Copy plain text to the clipboard.
+ * Prefers `navigator.clipboard`; falls back to a temporary textarea + execCommand.
+ * Returns whether the copy succeeded.
+ */
+export async function copyText(text: string): Promise<boolean> {
+  if (typeof navigator !== 'undefined' && navigator.clipboard?.writeText) {
+    try {
+      await navigator.clipboard.writeText(text)
+      return true
+    } catch {
+      // fall through to legacy path
+    }
+  }
+
+  if (typeof document === 'undefined') {
+    return false
+  }
+
+  try {
+    const ta = document.createElement('textarea')
+    ta.value = text
+    ta.setAttribute('readonly', '')
+    ta.style.position = 'fixed'
+    ta.style.left = '-9999px'
+    ta.style.top = '0'
+    document.body.appendChild(ta)
+    ta.focus()
+    ta.select()
+    const ok = document.execCommand('copy')
+    document.body.removeChild(ta)
+    return ok
+  } catch {
+    return false
+  }
+}

--- a/browser/flagr-ui/src/helpers/shareLinks.test.ts
+++ b/browser/flagr-ui/src/helpers/shareLinks.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest'
+import {
+  FLAG_TAB_CONFIG,
+  FLAG_TAB_HISTORY,
+  buildAppUrl,
+  flagHistoryUrl,
+  flagSnapshotUrl,
+  flagUrl,
+  parseFlagDeepLink,
+  snapshotElementId,
+} from './shareLinks'
+
+const loc = {
+  origin: 'https://flagr.example.com',
+  pathname: '/ui/',
+  search: '',
+}
+
+describe('shareLinks', () => {
+  it('buildAppUrl joins origin, pathname, search, and hash path', () => {
+    expect(buildAppUrl('/flags/42', loc)).toBe('https://flagr.example.com/ui/#/flags/42')
+    expect(
+      buildAppUrl('/flags/42', { ...loc, search: '?embed=1' }),
+    ).toBe('https://flagr.example.com/ui/?embed=1#/flags/42')
+  })
+
+  it('flagUrl is absolute Config deep link', () => {
+    expect(flagUrl(42, loc)).toBe('https://flagr.example.com/ui/#/flags/42')
+    expect(flagUrl('7', loc)).toBe('https://flagr.example.com/ui/#/flags/7')
+  })
+
+  it('flagHistoryUrl includes tab=history', () => {
+    expect(flagHistoryUrl(42, loc)).toBe(
+      'https://flagr.example.com/ui/#/flags/42?tab=history',
+    )
+  })
+
+  it('flagSnapshotUrl includes tab and snapshot', () => {
+    expect(flagSnapshotUrl(42, 87, loc)).toBe(
+      'https://flagr.example.com/ui/#/flags/42?tab=history&snapshot=87',
+    )
+  })
+
+  it('snapshotElementId is stable', () => {
+    expect(snapshotElementId(87)).toBe('snapshot-87')
+  })
+
+  it('parseFlagDeepLink defaults to config', () => {
+    expect(parseFlagDeepLink(undefined)).toEqual({
+      tab: FLAG_TAB_CONFIG,
+      snapshotId: null,
+    })
+    expect(parseFlagDeepLink({})).toEqual({
+      tab: FLAG_TAB_CONFIG,
+      snapshotId: null,
+    })
+  })
+
+  it('parseFlagDeepLink reads history tab and snapshot', () => {
+    expect(parseFlagDeepLink({ tab: 'history' })).toEqual({
+      tab: FLAG_TAB_HISTORY,
+      snapshotId: null,
+    })
+    expect(parseFlagDeepLink({ tab: 'history', snapshot: '87' })).toEqual({
+      tab: FLAG_TAB_HISTORY,
+      snapshotId: 87,
+    })
+    // Snapshot alone implies history
+    expect(parseFlagDeepLink({ snapshot: '3' })).toEqual({
+      tab: FLAG_TAB_HISTORY,
+      snapshotId: 3,
+    })
+  })
+
+  it('parseFlagDeepLink ignores invalid snapshot values', () => {
+    expect(parseFlagDeepLink({ tab: 'history', snapshot: 'nope' })).toEqual({
+      tab: FLAG_TAB_HISTORY,
+      snapshotId: null,
+    })
+    expect(parseFlagDeepLink({ snapshot: '0' })).toEqual({
+      tab: FLAG_TAB_CONFIG,
+      snapshotId: null,
+    })
+    expect(parseFlagDeepLink({ snapshot: ['9', '10'] })).toEqual({
+      tab: FLAG_TAB_HISTORY,
+      snapshotId: 9,
+    })
+  })
+})

--- a/browser/flagr-ui/src/helpers/shareLinks.ts
+++ b/browser/flagr-ui/src/helpers/shareLinks.ts
@@ -1,0 +1,84 @@
+/** Deep-link query keys for the flag detail page (hash router). */
+export const FLAG_QUERY_TAB = 'tab'
+export const FLAG_QUERY_SNAPSHOT = 'snapshot'
+
+export const FLAG_TAB_CONFIG = 'config'
+export const FLAG_TAB_HISTORY = 'history'
+
+export type FlagTabName = typeof FLAG_TAB_CONFIG | typeof FLAG_TAB_HISTORY
+
+/** DOM id for a history snapshot card (scroll target). */
+export function snapshotElementId(snapshotId: string | number): string {
+  return `snapshot-${snapshotId}`
+}
+
+/** Minimal location surface so helpers stay unit-testable without a real window. */
+export type LocationLike = Pick<Location, 'origin' | 'pathname' | 'search'>
+
+export function buildAppUrl(hashPath: string, loc: LocationLike): string {
+  const path = hashPath.startsWith('/') ? hashPath : `/${hashPath}`
+  return `${loc.origin}${loc.pathname}${loc.search}#${path}`
+}
+
+/** Absolute UI URL for a flag (Config tab — default). */
+export function flagUrl(flagId: string | number, loc: LocationLike): string {
+  return buildAppUrl(`/flags/${flagId}`, loc)
+}
+
+/** Absolute UI URL for a flag History tab. */
+export function flagHistoryUrl(flagId: string | number, loc: LocationLike): string {
+  return buildAppUrl(`/flags/${flagId}?${FLAG_QUERY_TAB}=${FLAG_TAB_HISTORY}`, loc)
+}
+
+/** Absolute UI URL for a specific history snapshot block. */
+export function flagSnapshotUrl(
+  flagId: string | number,
+  snapshotId: string | number,
+  loc: LocationLike,
+): string {
+  const q = new URLSearchParams({
+    [FLAG_QUERY_TAB]: FLAG_TAB_HISTORY,
+    [FLAG_QUERY_SNAPSHOT]: String(snapshotId),
+  })
+  return buildAppUrl(`/flags/${flagId}?${q.toString()}`, loc)
+}
+
+export interface FlagDeepLink {
+  tab: FlagTabName
+  snapshotId: number | null
+}
+
+/** Parse flag deep-link intent from vue-router query (values may be string | string[]). */
+export function parseFlagDeepLink(
+  query: Record<string, unknown> | undefined | null,
+): FlagDeepLink {
+  if (!query) {
+    return { tab: FLAG_TAB_CONFIG, snapshotId: null }
+  }
+
+  const rawTab = firstQueryValue(query[FLAG_QUERY_TAB])
+  const rawSnapshot = firstQueryValue(query[FLAG_QUERY_SNAPSHOT])
+
+  let snapshotId: number | null = null
+  if (rawSnapshot != null && rawSnapshot !== '') {
+    const n = Number(rawSnapshot)
+    if (Number.isFinite(n) && n > 0) {
+      snapshotId = n
+    }
+  }
+
+  if (rawTab === FLAG_TAB_HISTORY || snapshotId != null) {
+    return { tab: FLAG_TAB_HISTORY, snapshotId }
+  }
+
+  return { tab: FLAG_TAB_CONFIG, snapshotId: null }
+}
+
+function firstQueryValue(value: unknown): string | null {
+  if (value == null) return null
+  if (Array.isArray(value)) {
+    const first = value[0]
+    return first == null ? null : String(first)
+  }
+  return String(value)
+}

--- a/browser/flagr-ui/src/pages/flagPage.test.ts
+++ b/browser/flagr-ui/src/pages/flagPage.test.ts
@@ -1,9 +1,16 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { FlagPageVm } from './flagPage'
-import { mountFlagPage } from './flagPage'
+import {
+  applyDeepLink,
+  mountFlagPage,
+  scrollToSnapshot,
+} from './flagPage'
+import { SNAPSHOT_HIGHLIGHT_MS } from '@/helpers/copyText'
+import { FLAG_TAB_CONFIG, FLAG_TAB_HISTORY, snapshotElementId } from '@/helpers/shareLinks'
 
 vi.mock('@/api/crud', () => ({
   loadFlagPageContext: vi.fn(() => new Promise(() => {})),
+  listFlagSnapshots: vi.fn(() => new Promise(() => {})),
 }))
 
 function minimalVm(overrides: Partial<FlagPageVm> = {}): FlagPageVm {
@@ -11,10 +18,12 @@ function minimalVm(overrides: Partial<FlagPageVm> = {}): FlagPageVm {
     flagId: '42',
     flag: { description: '', tags: [], variants: [], segments: [] },
     loaded: true,
+    activeTab: FLAG_TAB_CONFIG,
     historyLoaded: true,
     historyKey: 0,
     flagPageLoadGen: 0,
     flagSnapshots: [{ id: 1 }],
+    pendingSnapshotScrollId: null,
     dialogDuplicateFlagVisible: true,
     dialogEditDistributionOpen: true,
     dialogCreateSegmentOpen: true,
@@ -40,18 +49,93 @@ describe('mountFlagPage', () => {
   })
 
   it('resets route-local state and bumps flagPageLoadGen', () => {
-    const vm = minimalVm({ flagPageLoadGen: 3 })
+    const vm = minimalVm({
+      flagPageLoadGen: 3,
+      activeTab: FLAG_TAB_HISTORY,
+      pendingSnapshotScrollId: 9,
+    })
     mountFlagPage(vm)
 
     expect(vm.flagPageLoadGen).toBe(4)
     expect(vm.loaded).toBe(false)
+    expect(vm.activeTab).toBe(FLAG_TAB_CONFIG)
     expect(vm.historyLoaded).toBe(false)
     expect(vm.historyKey).toBe(1)
     expect(vm.flagSnapshots).toEqual([])
+    expect(vm.pendingSnapshotScrollId).toBeNull()
     expect(vm.dialogDuplicateFlagVisible).toBe(false)
     expect(vm.dialogEditDistributionOpen).toBe(false)
     expect(vm.dialogCreateSegmentOpen).toBe(false)
     expect(vm.selectedSegment).toBeNull()
     expect(vm.duplicateInFlight).toBe(false)
+  })
+})
+
+describe('applyDeepLink', () => {
+  it('opens history and queues snapshot scroll', () => {
+    const vm = minimalVm({ historyKey: 2, historyLoaded: false })
+    applyDeepLink(vm, { tab: 'history', snapshot: '87' })
+
+    expect(vm.activeTab).toBe(FLAG_TAB_HISTORY)
+    expect(vm.historyLoaded).toBe(true)
+    expect(vm.historyKey).toBe(3)
+    expect(vm.pendingSnapshotScrollId).toBe(87)
+  })
+
+  it('resets to config when query has no history intent', () => {
+    const vm = minimalVm({
+      activeTab: FLAG_TAB_HISTORY,
+      pendingSnapshotScrollId: 3,
+    })
+    applyDeepLink(vm, {})
+
+    expect(vm.activeTab).toBe(FLAG_TAB_CONFIG)
+    expect(vm.pendingSnapshotScrollId).toBeNull()
+  })
+})
+
+describe('scrollToSnapshot', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.unstubAllGlobals()
+  })
+
+  it('scrolls, highlights, and clears highlight after timeout', () => {
+    vi.useFakeTimers()
+    const el = {
+      id: snapshotElementId(5),
+      classList: {
+        tokens: new Set<string>(),
+        add(c: string) {
+          this.tokens.add(c)
+        },
+        remove(c: string) {
+          this.tokens.delete(c)
+        },
+        contains(c: string) {
+          return this.tokens.has(c)
+        },
+      },
+      scrollIntoView: vi.fn(),
+    }
+    vi.stubGlobal('document', {
+      getElementById: (id: string) => (id === el.id ? el : null),
+    })
+    vi.stubGlobal('window', {
+      matchMedia: () => ({ matches: true }),
+      setTimeout: globalThis.setTimeout.bind(globalThis),
+    })
+
+    expect(scrollToSnapshot(5)).toBe(true)
+    expect(el.scrollIntoView).toHaveBeenCalled()
+    expect(el.classList.contains('snapshot-container--highlight')).toBe(true)
+
+    vi.advanceTimersByTime(SNAPSHOT_HIGHLIGHT_MS)
+    expect(el.classList.contains('snapshot-container--highlight')).toBe(false)
+  })
+
+  it('returns false when the snapshot node is missing', () => {
+    vi.stubGlobal('document', { getElementById: () => null })
+    expect(scrollToSnapshot(999)).toBe(false)
   })
 })

--- a/browser/flagr-ui/src/pages/flagPage.ts
+++ b/browser/flagr-ui/src/pages/flagPage.ts
@@ -1,3 +1,4 @@
+import { nextTick } from 'vue'
 import type { Router } from 'vue-router'
 import * as evalApi from '@/api/eval'
 import * as crudApi from '@/api/crud'
@@ -33,7 +34,16 @@ import {
 import { confirmAndRunApi, type ConfirmVm } from '@/helpers/runApi'
 import { materializeConstraintForApi } from '@/helpers/constraintOperatorSugar'
 import { runApi } from '@/helpers/runApi'
+import { SNAPSHOT_HIGHLIGHT_MS } from '@/helpers/copyText'
+import {
+  FLAG_TAB_CONFIG,
+  FLAG_TAB_HISTORY,
+  parseFlagDeepLink,
+  snapshotElementId,
+  type FlagTabName,
+} from '@/helpers/shareLinks'
 
+export const SNAPSHOT_NOT_FOUND_MESSAGE = 'Snapshot not found on this flag'
 
 export interface FlagPageVm extends ConfirmVm {
   $router: Router
@@ -53,9 +63,13 @@ export interface FlagPageVm extends ConfirmVm {
   selectedSegment: Segment | null
   distributionDraft: Record<string, DistributionDraft>
   loaded: boolean
+  /** Active el-tabs name: config | history. */
+  activeTab: FlagTabName
   historyLoaded: boolean
   historyKey: number
   flagSnapshots: FlagSnapshot[]
+  /** Snapshot id to scroll to after History finishes loading. */
+  pendingSnapshotScrollId: number | null
   evalContext: EvalContext
   evalResult: EvalResult
   evalSummary: EvalSummary | null
@@ -437,19 +451,83 @@ export function handleSaveDistribution(
 }
 
 export function handleHistoryTabClick(vm: FlagPageVm, tab: { props?: { name?: string } }): void {
-  if (tab.props?.name === 'history') {
-    vm.historyLoaded = true
-    vm.historyKey++
-    loadFlagSnapshots(vm)
+  if (tab.props?.name === FLAG_TAB_HISTORY) {
+    openHistoryTab(vm)
   }
+}
+
+/** Load (or reload) flag snapshots for the History tab. */
+export function openHistoryTab(vm: FlagPageVm): void {
+  vm.activeTab = FLAG_TAB_HISTORY
+  vm.historyLoaded = true
+  vm.historyKey++
+  loadFlagSnapshots(vm)
 }
 
 export function loadFlagSnapshots(vm: FlagPageVm): void {
   runApi(vm, crudApi.listFlagSnapshots(vm.flagId), {
     onSuccess: (data) => {
       vm.flagSnapshots = data
+      const pending = vm.pendingSnapshotScrollId
+      if (pending == null) return
+      vm.pendingSnapshotScrollId = null
+      void scrollToSnapshotWhenReady(vm, pending)
     },
   })
+}
+
+/** Wait for FlagHistory cards to mount, then scroll/highlight (with one short retry). */
+async function scrollToSnapshotWhenReady(vm: FlagPageVm, snapshotId: number): Promise<void> {
+  await nextTick()
+  if (scrollToSnapshot(snapshotId)) return
+  await new Promise<void>((resolve) => {
+    requestAnimationFrame(() => resolve())
+  })
+  if (scrollToSnapshot(snapshotId)) return
+  vm.$message.warning(SNAPSHOT_NOT_FOUND_MESSAGE)
+}
+
+/**
+ * Apply deep-link query (`tab`, `snapshot`) after the flag page is ready.
+ * Safe to call on every query change while loaded.
+ */
+export function applyDeepLink(
+  vm: FlagPageVm,
+  query: Record<string, unknown> | undefined | null,
+): void {
+  const link = parseFlagDeepLink(query)
+  if (link.tab === FLAG_TAB_HISTORY) {
+    if (link.snapshotId != null) {
+      vm.pendingSnapshotScrollId = link.snapshotId
+    }
+    // Always (re)open history so a fresh paste reloads + scrolls.
+    openHistoryTab(vm)
+    return
+  }
+  vm.activeTab = FLAG_TAB_CONFIG
+  vm.pendingSnapshotScrollId = null
+}
+
+/** Scroll to a snapshot card and apply a one-shot highlight. Returns whether the node existed. */
+export function scrollToSnapshot(snapshotId: number): boolean {
+  if (typeof document === 'undefined') return false
+  const el = document.getElementById(snapshotElementId(snapshotId))
+  if (!el) return false
+
+  const reduceMotion =
+    typeof window !== 'undefined' &&
+    typeof window.matchMedia === 'function' &&
+    window.matchMedia('(prefers-reduced-motion: reduce)').matches
+
+  el.scrollIntoView({
+    block: 'center',
+    behavior: reduceMotion ? 'auto' : 'smooth',
+  })
+  el.classList.add('snapshot-container--highlight')
+  window.setTimeout(() => {
+    el.classList.remove('snapshot-container--highlight')
+  }, SNAPSHOT_HIGHLIGHT_MS)
+  return true
 }
 
 export function postEvaluation(vm: FlagPageVm, evalContext: EvalContext): void {
@@ -480,12 +558,14 @@ export function syncEvalContextFromFlag(vm: FlagPageVm): void {
 }
 
 /** Loads flag page context; resets route-local state and bumps load generation (route watcher). */
-export function mountFlagPage(vm: FlagPageVm): void {
+export function mountFlagPage(vm: FlagPageVm, routeQuery?: Record<string, unknown> | null): void {
   vm.flagPageLoadGen = (vm.flagPageLoadGen ?? 0) + 1
   vm.loaded = false
+  vm.activeTab = FLAG_TAB_CONFIG
   vm.historyLoaded = false
   vm.historyKey++
   vm.flagSnapshots = []
+  vm.pendingSnapshotScrollId = null
   vm.dialogDuplicateFlagVisible = false
   vm.dialogEditDistributionOpen = false
   vm.dialogCreateSegmentOpen = false
@@ -505,6 +585,9 @@ export function mountFlagPage(vm: FlagPageVm): void {
       vm.entityTypes = load.entityTypes
       vm.allowCreateEntityType = load.allowCreateEntityType
       syncEvalContextFromFlag(vm)
+      if (routeQuery) {
+        applyDeepLink(vm, routeQuery)
+      }
     },
   })
 }

--- a/browser/flagr-ui/src/styles/app.scss
+++ b/browser/flagr-ui/src/styles/app.scss
@@ -239,6 +239,18 @@ ol { margin: 0; padding-left: 20px; }
 
   .el-breadcrumb { margin-bottom: var(--space-md); }
 
+  // One-shot highlight when opening a deep-linked history snapshot.
+  .snapshot-container--highlight {
+    box-shadow: 0 0 0 2px var(--el-color-primary-light-5);
+    background-color: var(--el-color-primary-light-9);
+    transition: box-shadow 150ms ease, background-color 150ms ease;
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .snapshot-container--highlight {
+      transition: none;
+    }
+  }
+
   .el-input { margin-bottom: 2px; }
 
   .segment-rollout-percent input { text-align: right; }


### PR DESCRIPTION
## Description

Add **copy-as-URL** controls on the flag detail page so operators can share durable deep links:

- **Flag config** — icon next to the flag `#id` copies an absolute URL to `#/flags/:id` (host from `window.location`).
- **History / audit** — each snapshot card can copy a link to that change: `#/flags/:id?tab=history&snapshot=:id`.
- **Deep-link open** — visiting a history/snapshot URL selects the History tab, loads snapshots, scrolls to the card, and applies a short one-shot highlight.

Also introduces reusable helpers (`shareLinks`, `copyText`) and a small `CopyLinkButton` (icon-only, “Copied” state, no success toast).

## Motivation and Context

Flag owners and on-call often paste links into Slack, PRs, and tickets. Today the browser URL only identifies the flag; History and a specific snapshot cannot be shared. Absolute URLs built from the current `location` work across local, staging, and prod without hard-coding a host.

## How Has This Been Tested?

- `make flagr-ui-check` (ESLint, `vue-tsc`, Vitest) — unit tests for URL builders, clipboard helper, deep-link apply/scroll.
- Playwright e2e (with API on `:18000` and Vite on `:8080`):
  - `copy flag URL and deep-link to a history snapshot`
  - related flag-detail cases: loads, sections, history tab, duplicate flag

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.