### PR TITLE
fix(ci): restore docs build and add docs_build job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,19 @@ jobs:
           cache: 'npm'
           cache-dependency-path: browser/flagr-ui/package-lock.json
       - run: make build-ui
+  # Same build as pages.yml (make build-docs). Catches dead VitePress links and
+  # docs package/lock issues on PRs before Deploy docs to GitHub Pages runs on main.
+  docs_build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out source code
+        uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: docs/package-lock.json
+      - run: make build-docs
   integration_test:
     runs-on: ubuntu-latest
     steps:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,7 @@ Run **`make help`** from the repo root for the full catalog. Common targets:
 |---|---|
 | `make build` | Go server → `./flagr` |
 | `make build-ui` | UI: lint, typecheck, Vite → `browser/flagr-ui/dist/` |
+| `make build-docs` | VitePress production build → `docs/.vitepress/dist` |
 | `make start` | Backend `:18000` + UI dev `:8080` |
 | `make stop-ui` | Free ports `:18000` / `:8080` (`lsof`, not `pkill`) |
 | `make rebuild-run` | `build` → `stop-ui` → `start` |
@@ -29,6 +30,7 @@ Run from **repo root**. Match what [`.github/workflows/ci.yml`](.github/workflow
 | You changed | Run before commit | Run before push (recommended) |
 |-------------|-------------------|-------------------------------|
 | **`browser/flagr-ui/`** only | `make flagr-ui-check` | `make test-e2e` |
+| **`docs/`** (VitePress) | `make build-docs` | `make build-docs` |
 | **`pkg/`** or Go tests | `make test` | `make test` (+ `make test-integration` if handler/API behavior) |
 | **Swagger** (`swagger/`, handlers → OpenAPI) | `make swagger` then commit `swagger_gen/` + `cmd/flagr-server/main.go` | `make ci-swagger` (regen + `git diff --exit-code`) |
 | **UI + Go** or unsure | `make test` **and** `make flagr-ui-check` | `make test` + `make test-e2e` |
@@ -39,6 +41,7 @@ Run from **repo root**. Match what [`.github/workflows/ci.yml`](.github/workflow
 |--------------------|----------|
 | `unit_test` | `make ci-swagger` then `make ci` (= `make test`: **golangci-lint** + swagger validate + `go test ./pkg/...`) |
 | `ui_lint` | `make build-ui` (= `flagr-ui-check` + Vite production build) |
+| `docs_build` | `make build-docs` (VitePress; same as Pages deploy) |
 | `e2e_test` | `make test-e2e` (= `make build` + `flagr-ui-check` + Playwright) |
 | `integration_test` | `make ci-integration` (Docker Compose; usually not every UI PR) |
 

--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,7 @@ help:
 	@echo "CI (GitHub Actions call these)"
 	@echo "  make ci                Unit test gate (lint + swagger + go test)"
 	@echo "  make ci-swagger        Regenerate swagger; fail if git dirty"
+	@echo "  make build-docs        VitePress docs build (docs_build job + Pages)"
 	@echo "  make ci-integration    Compose integration tests + benchmarks"
 	@echo ""
 	@echo "Other"

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -95,9 +95,9 @@ The docs site is a **VitePress** app whose sources live in `docs/` (`index.md` i
 | **`make build-docs`** | Sync env snippet, `npm ci`, production build → `docs/.vitepress/dist` (+ copy `api_docs/`, patch sitemap) |
 | **`make docs-sync-snippets`** | Copy `pkg/config/env.go` → `docs/snippets/env.go` (used by serve/build) |
 
-On push to `main`, [pages.yml](https://github.com/openflagr/flagr/blob/main/.github/workflows/pages.yml) runs `make build-docs` and deploys `docs/.vitepress/dist` to GitHub Pages.
+Every PR runs `make build-docs` in the **docs_build** CI job (same command as deploy). On push to `main`, [pages.yml](https://github.com/openflagr/flagr/blob/main/.github/workflows/pages.yml) builds again and deploys `docs/.vitepress/dist` to GitHub Pages.
 
-SEO / AI-readable assets live in `docs/public/` (`robots.txt`, `llms.txt`, images). OpenAPI ReDoc stays in `docs/api_docs/` and is copied into the dist on build. Full as-built: [VitePress docs SEO plan](plans/2026-07-14-001-vitepress-docs-seo-plan.md) (repo path; not on the live docs sidebar).
+SEO / AI-readable assets live in `docs/public/` (`robots.txt`, `llms.txt`, images). OpenAPI ReDoc stays in `docs/api_docs/` and is copied into the dist on build. Full as-built: [VitePress docs SEO plan](https://github.com/openflagr/flagr/blob/main/docs/plans/2026-07-14-001-vitepress-docs-seo-plan.md) (repo path; not on the live docs sidebar).
 
 Several pages serve specific audiences and are worth knowing as a contributor: the [integration guide](integration.md) is the hub for integrators, the [behavioral contracts](flagr_behavioral_contracts.md) hold the canonical descriptions of cross-cutting behavior, and this page is the repo guide. Design and as-built notes live in `docs/plans/` — they are excluded from the VitePress sidebar build, but remain valuable internal history.
 


### PR DESCRIPTION
## Summary

- **Root cause:** VitePress `make build-docs` (and thus *Deploy docs to GitHub Pages* on `main`) failed because `docs/CONTRIBUTING.md` had a relative link to `plans/2026-07-14-001-vitepress-docs-seo-plan.md`. Plan files are `srcExclude`d from the site, so dead-link checking fails the build.
- **Fix:** Use a GitHub blob URL for that plan (same pattern as other plan links on the site).
- **Prevention:** Add a **`docs_build`** job to `.github/workflows/ci.yml` that runs `make build-docs` on every PR/push (Node 22 + `docs/package-lock.json` cache, matching `pages.yml`).

Also documents the job in `AGENTS.md` / Makefile help so agents and contributors run `make build-docs` when touching `docs/`.

## Test plan

- [x] `make build-docs` succeeds locally after the link fix
- [ ] CI `docs_build` job green on this PR
- [ ] After merge, *Deploy docs to GitHub Pages* on `main` succeeds