### PR TITLE
fix(ui): use relative asset and API paths so FLAGR_WEB_PREFIX works

### DIFF
--- a/browser/flagr-ui/src/helpers/constants.ts
+++ b/browser/flagr-ui/src/helpers/constants.ts
@@ -1,4 +1,6 @@
-const API_URL = import.meta.env.VITE_API_URL || '/api/v1'
+// Relative by default so API calls respect a FLAGR_WEB_PREFIX subpath
+// deployment; resolves to /api/v1 when served at the root.
+const API_URL = import.meta.env.VITE_API_URL || 'api/v1'
 const rawEntityTypes = import.meta.env.VITE_FLAGR_UI_POSSIBLE_ENTITY_TYPES
 const FLAGR_UI_POSSIBLE_ENTITY_TYPES =
   rawEntityTypes && rawEntityTypes !== 'null' ? rawEntityTypes : null

--- a/browser/flagr-ui/vite.config.mjs
+++ b/browser/flagr-ui/vite.config.mjs
@@ -5,6 +5,11 @@ import { fileURLToPath } from 'url'
 const srcDir = fileURLToPath(new URL('src', import.meta.url))
 
 export default defineConfig({
+  // Relative base so the built assets load when Flagr is served under a
+  // path prefix (FLAGR_WEB_PREFIX), e.g. https://example.com/flagr/.
+  // Safe because the router uses hash history, so the document URL always
+  // points at the app root.
+  base: './',
   plugins: [vue()],
   resolve: {
     alias: {


### PR DESCRIPTION
## Description

Since the Vite migration (1.2.0), the built UI references its assets with absolute URLs (`/static/index-<hash>.js`) and defaults the API base to an absolute path (`/api/v1`). When Flagr is served under a subpath via `FLAGR_WEB_PREFIX` (e.g. behind an ingress at `https://example.com/flagr`), the server correctly mounts the UI and API under the prefix, but the browser fetches assets and API from the domain root, so the UI fails to load with:

```
Failed to load module script: Expected a JavaScript-or-Wasm module script
but the server responded with a MIME type of "text/html".
```

This PR restores the pre-Vite (<= 1.1.x) behavior, which used relative paths (`BASE_URL=""`, `VUE_APP_API_URL=api/v1`):

- set Vite `base: './'` so built asset URLs are relative
- default `API_URL` to `api/v1` (relative) instead of `/api/v1`

Relative URLs are safe here because the router uses hash history (`createWebHashHistory`), so the document URL always points at the app root, and `negroni.Static` redirects the bare prefix to a trailing slash. Root-path deployments are unaffected: at `/`, `./static/x.js` resolves to `/static/x.js` and `api/v1` resolves to `/api/v1`. The `VITE_API_URL` override still works as before.

## Motivation and Context

`FLAGR_WEB_PREFIX` is documented as "UI + API base path", but since 1.2.0 the shipped `ghcr.io/openflagr/flagr` image cannot serve a working UI under a subpath, and nothing can be overridden at runtime because Vite inlines these values at build time. This is a regression from 1.1.x, where subpath deployments worked end to end.

## How Has This Been Tested?

- `npm run build`: `dist/index.html` now emits `./static/index-<hash>.js`, `./static/index-<hash>.css`, and `./favicon.png`
- `npm run test`: 74/74 unit tests pass
- `npm run lint` and `npm run typecheck`: clean
- Reproduced the original failure on a Kubernetes deployment (Traefik ingress routing `/flag` to Flagr with `FLAGR_WEB_PREFIX=/flag`) running 1.2.2; with this change the module script and API requests resolve under the prefix

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
