### PR TITLE
Prepare 1.2.3 release

### DIFF
--- a/browser/flagr-ui/package-lock.json
+++ b/browser/flagr-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "flagr-ui",
-    "version": "1.2.2",
+    "version": "1.2.3",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "flagr-ui",
-            "version": "1.2.2",
+            "version": "1.2.3",
             "dependencies": {
                 "@element-plus/icons-vue": "^2.3.1",
                 "@vscode/markdown-it-katex": "^1.1.2",

--- a/browser/flagr-ui/package.json
+++ b/browser/flagr-ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "flagr-ui",
-    "version": "1.2.2",
+    "version": "1.2.3",
     "private": true,
     "scripts": {
         "dev": "vite",

--- a/docs/api_docs/bundle.yaml
+++ b/docs/api_docs/bundle.yaml
@@ -4,7 +4,7 @@ info:
     Flagr is a feature flagging, A/B testing and dynamic configuration
     microservice. The base path for all the APIs is "/api/v1".
   title: Flagr
-  version: 1.2.2
+  version: 1.2.3
 tags:
   - name: flag
     description: Everything about the flag

--- a/swagger/index.yaml
+++ b/swagger/index.yaml
@@ -5,7 +5,7 @@ info:
     Flagr is a feature flagging, A/B testing and dynamic configuration microservice.
     The base path for all the APIs is "/api/v1".
   title: Flagr
-  version: 1.2.2
+  version: 1.2.3
 tags:
   - name: flag
     description: Everything about the flag

--- a/swagger_gen/restapi/doc.go
+++ b/swagger_gen/restapi/doc.go
@@ -8,7 +8,7 @@
 //	  http
 //	Host: localhost
 //	BasePath: /api/v1
-//	Version: 1.2.2
+//	Version: 1.2.3
 //
 //	Consumes:
 //	  - application/json

--- a/swagger_gen/restapi/embedded_spec.go
+++ b/swagger_gen/restapi/embedded_spec.go
@@ -28,7 +28,7 @@ func init() {
   "info": {
     "description": "Flagr is a feature flagging, A/B testing and dynamic configuration microservice. The base path for all the APIs is \"/api/v1\".\n",
     "title": "Flagr",
-    "version": "1.2.2"
+    "version": "1.2.3"
   },
   "basePath": "/api/v1",
   "paths": {
@@ -2681,7 +2681,7 @@ func init() {
   "info": {
     "description": "Flagr is a feature flagging, A/B testing and dynamic configuration microservice. The base path for all the APIs is \"/api/v1\".\n",
     "title": "Flagr",
-    "version": "1.2.2"
+    "version": "1.2.3"
   },
   "basePath": "/api/v1",
   "paths": {


### PR DESCRIPTION
Closes #762

## Changes since 1.2.2

### Features
- feat: built-in evaluation context injection (`@ts`, `@http_*`) (#738)
- feat(api): GET evaluation via `?json=` query param (#740)
- feat(ui): copy flag and history snapshot deep links (#746)
- feat(ui): quieter chrome, less motion, softer light theme (#744)

### Fixes
- fix(ui): use relative asset and API paths so `FLAGR_WEB_PREFIX` works (#754)
- fix(docs): restore Mermaid rendering and add click-to-enlarge zoom (#752)
- fix(deps): resolve open Dependabot alerts in docs Vite stack (#750)
- fix(ci): restore docs build and gate PRs with `docs_build` (#748)

### Docs
- docs: VitePress docs site, SEO/LLM surface, and Flagr brand lockup (#745)
- docs: accurate behavioral contracts and leaner guide set (#742)
- docs: restructure guides, Docsify theme, and link compatibility (#741)
- docs(brand): solid backgrounds for logos and fix README image paths (#749)

### Performance
- perf(ci): speed up CI with dependency caching and test parallelism (#739)

### Dependencies
- chore(deps): bump `golang.org/x/crypto` from 0.51.0 to 0.52.0 (#743)
- chore(deps): bump `google.golang.org/grpc` from 1.79.3 to 1.82.1 (#756)
- chore(deps): bump `dompurify` from 3.4.10 to 3.4.12 in /docs (#747)
- chore(deps): bump `brace-expansion`, `eslint` and `vue-tsc` (#753)
- chore(deps): bump `immutable` from 5.1.6 to 5.1.9 in /browser/flagr-ui (#755)
- chore(deps): bump `fast-uri` from 3.1.2 to 3.1.4 in /browser/flagr-ui (#759)
- chore(deps): bump `linkify-it` from 5.0.1 to 5.0.2 in /browser/flagr-ui (#757)
- chore(deps): bump `postcss` from 8.5.15 to 8.5.23 in /browser/flagr-ui (#760)

### Version bump
- `swagger/index.yaml`
- `docs/api_docs/bundle.yaml`
- `swagger_gen/restapi/doc.go`
- `swagger_gen/restapi/embedded_spec.go`
- `browser/flagr-ui/package.json`
- `browser/flagr-ui/package-lock.json`

## Motivation and Context

Requested in #762. `main` has 21 commits since [1.2.2](https://github.com/openflagr/flagr/releases/tag/1.2.2) (2026-07-03), including the `FLAGR_WEB_PREFIX` regression fix (#754) and eight security/dependency bumps. Since `cd_docker.yml` publishes images only on `release: published`, none of it is consumable from the released `ghcr.io/openflagr/flagr` images yet.

`1.2.3` follows this repo's convention — 1.2.2 also shipped `feat` commits as a patch, with minor bumps reserved for larger milestones (1.2.0 carried the Vue 2→3 / Vite migration).

## How Has This Been Tested?

Version bump only — no behavioral changes. The generated files were produced by the toolchain, not hand-edited (`swagger-merger` for `bundle.yaml`, `go-swagger` v0.34.1 for `swagger_gen/`).

- `make test` — `verify_fmt` clean, `verify_lint` 0 issues, `verify_swagger` valid against Swagger 2.0, all Go unit tests pass
- `make ci-swagger` — regenerated and `git diff --exit-code` clean, so `swagger_gen/` matches the spec
- `make flagr-ui-check` — lint, typecheck and 74/74 UI unit tests pass

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Neither — release version bump.

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
